### PR TITLE
[SELC-5465] fix: Calculation of moduleOfEpoch Attribute Based on Onboarding Creation Date

### DIFF
--- a/apps/institution-ms/app/src/main/resources/config/core-config.properties
+++ b/apps/institution-ms/app/src/main/resources/config/core-config.properties
@@ -28,10 +28,8 @@ mscore.aws-ses-secret-id=${AWS_SES_ACCESS_KEY_ID:secret-id-example}
 mscore.aws-ses-secret-key=${AWS_SES_SECRET_ACCESS_KEY:secret-key-example}
 mscore.aws-ses-region=${AWS_SES_REGION:eu-south-1}
 
-mscore.sending-frequency-pec-notification=${SENDING_FREQUENCY_PEC_NOTIFICATION:30}
-mscore.epoch-date-pec-notification=${EPOCH_DATE_PEC_NOTIFICATION:2024-01-01}
-
 ## NOTIFICATION PRODUCT SENDING FREQUENCY ##
+mscore.institution-send-mail.epoch-date-pec-notification=${EPOCH_DATE_PEC_NOTIFICATION:2024-01-01}
 mscore.institution-send-mail.scheduler.pec-notification-disabled=${PEC_NOTIFICATION_DISABLED:false}
 
 mscore.institution-send-mail.scheduler.products.prod-interop=30

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/config/InstitutionSendMailConfig.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/config/InstitutionSendMailConfig.java
@@ -13,6 +13,7 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "mscore.institution-send-mail.scheduler")
 public class InstitutionSendMailConfig {
 
+    String epochDatePecNotification;
     Boolean pecNotificationDisabled;
     Map<String, Integer> products;
 }

--- a/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImpl.java
+++ b/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImpl.java
@@ -77,6 +77,7 @@ public class InstitutionSendMailScheduledServiceImpl implements InstitutionSendM
         return Multi.createBy().repeating()
                 .uni(AtomicInteger::new,
                         currentPage -> runQueryAndSendNotification(moduleDayOfTheEpoch, currentPage.getAndIncrement(), productId))
+                .withDelay(Duration.ofSeconds(30))
                 .until(Boolean.FALSE::equals)
                 .collect()
                 .asList()
@@ -84,7 +85,7 @@ public class InstitutionSendMailScheduledServiceImpl implements InstitutionSendM
 
     }
 
-    private Uni<Boolean> runQueryAndSendNotification(Long moduleDayOfTheEpoch, int page, String productId) {
+    public Uni<Boolean> runQueryAndSendNotification(Long moduleDayOfTheEpoch, int page, String productId) {
         var pecNotificationPage = PecNotification.find(PecNotification.Fields.moduleDayOfTheEpoch.name() + "=?1 AND "
                         + PecNotification.Fields.productId.name() + "=?2", moduleDayOfTheEpoch, productId)
                 .page(page, querySize);

--- a/apps/institution-send-mail-scheduler/src/main/resources/application.properties
+++ b/apps/institution-send-mail-scheduler/src/main/resources/application.properties
@@ -15,7 +15,7 @@ institution-send-mail.destination-mail-test-address = ${MAIL_DESTINATION_TEST_AD
 institution-send-mail.notification-path= ${MAIL_TEMPLATE_NOTIFICATION_PATH:test.json}
 institution-send-mail.first-notification-path =${MAIL_TEMPLATE_FIRST_NOTIFICATION_PATH:test.json}
 
-institution-send-mail.notification-query-size = 1000
+institution-send-mail.notification-query-size = ${MAIL_QUERY_SIZE:10}
 institution-send-mail.notification-start-date = 2024-01-01
 institution-send-mail.notification-send-all = ${SEND_ALL_NOTIFICATION:false}
 

--- a/apps/institution-send-mail-scheduler/src/main/resources/application.properties
+++ b/apps/institution-send-mail-scheduler/src/main/resources/application.properties
@@ -12,8 +12,8 @@ institution-send-mail.destination-mail = ${MAIL_DESTINATION_TEST:true}
 ## If MAIL_DESTINATION_TEST is true, app send mail to this address
 institution-send-mail.destination-mail-test-address = ${MAIL_DESTINATION_TEST_ADDRESS:test@test.it}
 
-institution-send-mail.notification-path= ${MAIL_TEMPLATE_NOTIFICATION_PATH:test.json}
-institution-send-mail.first-notification-path =${MAIL_TEMPLATE_FIRST_NOTIFICATION_PATH:test.json}
+institution-send-mail.notification-path= ${MAIL_TEMPLATE_NOTIFICATION_PATH:contracts/template/mail/institution-user-list-notification/1.0.0.json}
+institution-send-mail.first-notification-path =${MAIL_TEMPLATE_FIRST_NOTIFICATION_PATH:contracts/template/mail/institution-user-list-first-notification/1.0.0.json}
 
 institution-send-mail.notification-query-size = ${MAIL_QUERY_SIZE:10}
 institution-send-mail.notification-start-date = 2024-01-01

--- a/infra/container_apps/institution-send-mail-scheduler/mongo_db.tf
+++ b/infra/container_apps/institution-send-mail-scheduler/mongo_db.tf
@@ -12,7 +12,7 @@ module "mongodb_collection_pec_notifications" {
     unique = true
     },
     {
-      keys   = ["moduleDayOfTheEpoch"]
+      keys   = ["moduleDayOfTheEpoch","productId"]
       unique = false
     }
   ]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Updated the calculation logic of the moduleOfEpoch attribute to use the onboarding object's creation date instead of the deployment date (now).
* Refactored the relevant code sections to ensure that the calculation is dynamically based on the correct date.
* Added unit tests to cover scenarios where the onboarding creation date differs from the current date.
* Decrease query size to support limit of Aruba PEC server

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request addresses a bug in the calculation of the moduleOfEpoch attribute. Previously, the calculation was incorrectly based on the now date, which was set during the deployment of the microservice. However, this approach caused inaccuracies when the moduleOfEpoch calculation needed to reflect the creation date of the onboarding object, which may differ from the current date.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.