### PR TITLE
[SELC-5486] hotfix: skip insert PecNotification if already exists

### DIFF
--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
@@ -56,7 +56,7 @@ public class PecNotificationConnectorImpl implements PecNotificationConnector {
 
         if (exist){
         	log.trace("Cannot insert the PecNotification: {}, as it already exists in the collection", pecNotification.toString());
-            return false;
+            return true;
         }
 
         repository.insert(pecNotificationEntity);

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
@@ -1,23 +1,23 @@
 package it.pagopa.selfcare.mscore.connector.dao;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
+import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
+import it.pagopa.selfcare.mscore.connector.dao.model.mapper.PecNotificationEntityMapper;
+import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ContextConfiguration;
 
-import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
-import it.pagopa.selfcare.mscore.connector.dao.model.mapper.PecNotificationEntityMapper;
-import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
 
 @ContextConfiguration(classes = {PecNotificationConnectorImpl.class})
 @ExtendWith(MockitoExtension.class)
@@ -99,7 +99,7 @@ class PecNotificationConnectorImplTest {
 
         boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
 
-        assertFalse(result);
+        assertTrue(result);
         verify(repository, never()).insert(pecNotificationEntity);
         
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
if PecNotification if already exists the insertion must be skipped because the sending will be performed

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.