### PR TITLE
[SELC-5599] feat: using InstitutionType from onboarding-sdk-common instead selc-commons

### DIFF
--- a/apps/institution-ms/app/src/main/docs/openapi.json
+++ b/apps/institution-ms/app/src/main/docs/openapi.json
@@ -2086,7 +2086,7 @@
           "style" : "simple",
           "schema" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           }
         } ],
         "responses" : {
@@ -2567,7 +2567,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "origin" : {
             "type" : "string"
@@ -2817,7 +2817,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "productId" : {
             "type" : "string"
@@ -2926,7 +2926,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "origin" : {
             "type" : "string",
@@ -2964,7 +2964,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "subunitCode" : {
             "type" : "string"
@@ -3085,7 +3085,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "onboardings" : {
             "type" : "object",
@@ -3227,7 +3227,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "onboarding" : {
             "type" : "array",
@@ -3329,7 +3329,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "istatCode" : {
             "type" : "string"
@@ -3442,7 +3442,7 @@
           },
           "institutionType" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "ivassCode" : {
             "type" : "string"

--- a/apps/institution-ms/app/src/main/docs/openapi.json
+++ b/apps/institution-ms/app/src/main/docs/openapi.json
@@ -2566,8 +2566,7 @@
             "type" : "string"
           },
           "institutionType" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           },
           "origin" : {
             "type" : "string"
@@ -2816,8 +2815,7 @@
             "type" : "string"
           },
           "institutionType" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           },
           "productId" : {
             "type" : "string"
@@ -2925,8 +2923,7 @@
             "type" : "string"
           },
           "institutionType" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           },
           "origin" : {
             "type" : "string",
@@ -3084,8 +3081,7 @@
             "type" : "boolean"
           },
           "institutionType" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           },
           "onboardings" : {
             "type" : "object",
@@ -3328,8 +3324,7 @@
             "type" : "boolean"
           },
           "institutionType" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
+            "type" : "string"
           },
           "istatCode" : {
             "type" : "string"

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.api;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.SearchMode;
 import it.pagopa.selfcare.mscore.model.institution.*;

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/Delegation.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/Delegation.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.model.delegation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.DelegationState;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
 import lombok.AllArgsConstructor;

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.model.institution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/InstitutionUpdate.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/InstitutionUpdate.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.model.institution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 import lombok.experimental.FieldNameConstants;
 

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/OnboardingRequest.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/OnboardingRequest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.model.onboarding;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.TokenType;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
 import it.pagopa.selfcare.mscore.model.institution.Billing;

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.GeoTaxonomyEntity;

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/InstitutionEntity.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/InstitutionEntity.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao.model;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.*;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import lombok.Data;

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/inner/InstitutionUpdateEntity.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/inner/InstitutionUpdateEntity.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao.model.inner;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.util.List;

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao.model.mapper;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
 import it.pagopa.selfcare.mscore.model.delegation.DelegationInstitution;
 import it.pagopa.selfcare.mscore.model.institution.Institution;

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.connector.dao.model.DelegationEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationEntityMapper;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationEntityMapperImpl;

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.*;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.InstitutionEntityMapper;

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionRepositoryTest.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionRepositoryTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.connector.dao.config.DaoConfigTest;
 import it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.AttributesEntity;

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/utils/TestUtils.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/utils/TestUtils.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.dao.utils;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.BillingEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.DataProtectionOfficerEntity;

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.SearchMode;
 import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.core.strategy;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;
 import it.pagopa.selfcare.mscore.constant.Origin;

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.core.strategy;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;
 import it.pagopa.selfcare.mscore.constant.CustomError;

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.core.strategy.input;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
 import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
 import lombok.Builder;

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.core;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.constant.DelegationState;
 import it.pagopa.selfcare.mscore.constant.DelegationType;

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -2,7 +2,7 @@ package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/TestUtils.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/TestUtils.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Env;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.TokenType;

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.core.strategy;
 
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;
 import it.pagopa.selfcare.mscore.constant.Origin;

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.core.util;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.model.institution.*;
 import it.pagopa.selfcare.mscore.model.onboarding.Contract;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -4,7 +4,7 @@ import io.swagger.annotations.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.InstitutionService;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.delegation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.DelegationState;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
 import lombok.Data;
@@ -25,7 +24,7 @@ public class DelegationResponse {
     @NotBlank
     private String productId;
     private String taxCode;
-    private InstitutionType institutionType;
+    private String institutionType;
     @NotBlank
     private String brokerId;
     private String brokerTaxCode;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.web.model.delegation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.DelegationState;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
 import lombok.Data;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/BulkInstitution.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/BulkInstitution.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
@@ -27,7 +26,7 @@ public class BulkInstitution {
     @NotNull
     private String description;
 
-    private InstitutionType institutionType;
+    private String institutionType;
 
     @NotNull
     private String digitalAddress;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/BulkInstitution.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/BulkInstitution.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionBillingResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionBillingResponse.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import lombok.Data;
 

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionBillingResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionBillingResponse.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import lombok.Data;
 
@@ -11,7 +10,7 @@ public class InstitutionBillingResponse {
     private Origin origin;
     private String originId;
     private String description;
-    private InstitutionType institutionType;
+    private String institutionType;
     private String digitalAddress;
     private String address;
     private String zipCode;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionFromIpaPost.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionFromIpaPost.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
 import lombok.Data;
 

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionManagementResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionManagementResponse.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.time.OffsetDateTime;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardingResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardingResponse.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.time.OffsetDateTime;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardingResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardingResponse.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.time.OffsetDateTime;
@@ -15,7 +14,7 @@ public class InstitutionOnboardingResponse {
     private String origin;
     private String originId;
     private String description;
-    private InstitutionType institutionType;
+    private String institutionType;
     private String digitalAddress;
     private String address;
     private String zipCode;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.time.OffsetDateTime;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.web.model.onboarding.OnboardedProductResponse;
 import lombok.Data;
 

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.web.model.onboarding.OnboardedProductResponse;
 import lombok.Data;
 
@@ -21,7 +20,7 @@ public class InstitutionResponse {
     @NotBlank
     private String originId;
     private String description;
-    private InstitutionType institutionType;
+    private String institutionType;
     private String digitalAddress;
     private String address;
     private String zipCode;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionUpdateRequest.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionUpdateRequest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import javax.validation.constraints.NotEmpty;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionUpdateResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionUpdateResponse.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 
 import java.util.List;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
@@ -8,6 +8,7 @@ import it.pagopa.selfcare.mscore.model.user.ProductManagerInfo;
 import it.pagopa.selfcare.mscore.web.model.institution.*;
 import it.pagopa.selfcare.mscore.web.model.onboarding.OnboardedProducts;
 import it.pagopa.selfcare.mscore.web.model.onboarding.ProductInfo;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
@@ -536,7 +536,7 @@ public class InstitutionMapperCustom {
         bulkInstitution.setOrigin(inst.getOrigin());
         bulkInstitution.setOriginId(inst.getOriginId());
         bulkInstitution.setDescription(inst.getDescription());
-        bulkInstitution.setInstitutionType(inst.getInstitutionType());
+        bulkInstitution.setInstitutionType(Optional.ofNullable(inst.getInstitutionType()).map(InstitutionType::name).orElse(null));
         bulkInstitution.setDigitalAddress(inst.getDigitalAddress());
         bulkInstitution.setAddress(inst.getAddress());
         bulkInstitution.setZipCode(inst.getZipCode());

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
@@ -43,7 +43,7 @@ public class InstitutionMapperCustom {
         response.setInstitutionId(institution.getId());
         response.setExternalId(institution.getExternalId());
         response.setDescription(institution.getDescription());
-        response.setInstitutionType(institution.getInstitutionType());
+        response.setInstitutionType(Optional.ofNullable(institution.getInstitutionType()).map(InstitutionType::name).orElse(null));
         response.setDigitalAddress(institution.getDigitalAddress());
         response.setAddress(institution.getAddress());
         response.setZipCode(institution.getZipCode());
@@ -411,7 +411,7 @@ public class InstitutionMapperCustom {
         response.setOrigin(institution.getOrigin());
         response.setOriginId(institution.getOriginId());
         response.setDescription(institution.getDescription());
-        response.setInstitutionType(institution.getInstitutionType());
+        response.setInstitutionType(Optional.ofNullable(institution.getInstitutionType()).map(InstitutionType::name).orElse(null));
         response.setDigitalAddress(institution.getDigitalAddress());
         response.setAddress(institution.getAddress());
         response.setZipCode(institution.getZipCode());

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/OnboardedInstitutionResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/OnboardedInstitutionResponse.java
@@ -2,7 +2,7 @@ package it.pagopa.selfcare.mscore.web.model.onboarding;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.model.institution.Billing;
 import it.pagopa.selfcare.mscore.web.model.institution.AttributesResponse;
 import it.pagopa.selfcare.mscore.web.model.institution.DataProtectionOfficerResponse;

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/InstitutionToNotifyResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/InstitutionToNotifyResponse.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.token;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.model.RootParent;
 import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
 import lombok.AllArgsConstructor;

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/TestUtils.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/TestUtils.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.model.institution.Billing;
 import it.pagopa.selfcare.mscore.model.institution.DataProtectionOfficer;

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/ExternalControllerTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/ExternalControllerTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.controller;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.ExternalService;
 import it.pagopa.selfcare.mscore.model.institution.*;

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerPdaTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerPdaTest.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.core.InstitutionService;
 import it.pagopa.selfcare.mscore.model.institution.Billing;

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -3,7 +3,7 @@ package it.pagopa.selfcare.mscore.web.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.DelegationService;
 import it.pagopa.selfcare.mscore.core.InstitutionService;

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustomTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustomTest.java
@@ -1,7 +1,7 @@
 package it.pagopa.selfcare.mscore.web.model.mapper;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Env;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/model/mapper/RelationshipMapperTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/model/mapper/RelationshipMapperTest.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.mapper;
 
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.model.institution.*;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardedProduct;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Replace selc-commons InstitutionType with onboarding-sdk InstitutionType
- Update openapi.json because new type PRV has been added
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
 selc-commons  will be deprecated in order to use onboarding-sdk-common in each microservice

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.