### PR TITLE
[SELC-5701] Feat: Removed PT from insert PecNotification

### DIFF
--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -12,6 +12,7 @@ import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.Onboarding;
 import it.pagopa.selfcare.mscore.model.onboarding.VerifyOnboardingFilters;
 import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.http.HttpStatus;
@@ -109,8 +110,9 @@ public class OnboardingServiceImpl implements OnboardingService {
             productId, Onboarding onboarding, StringBuilder httpStatus) {
 
         Institution institution = persistAndGetInstitution(institutionId, productId, onboarding, httpStatus);
-        insertPecNotification(institutionId, productId, institution.getDigitalAddress(), onboarding.getCreatedAt());
-
+        if (!InstitutionType.PT.equals(institution.getInstitutionType())) {
+            insertPecNotification(institutionId, productId, institution.getDigitalAddress(), onboarding.getCreatedAt());
+        }
         return institution;
     }
 


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added check on institutionType in persistOnboarding method to insert PecNotification entity only if the institutionType is not PT
<!--- Describe your changes in detail -->

#### Motivation and Context
For institutions with institutionType = PT, the PEC notification entity must not be created.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.