### PR TITLE
[SELC-5964] hotfix: Enhance Validation of DigitalAddress and Adjust Retry Configuration

### DIFF
--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PecNotificationConnector.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PecNotificationConnector.java
@@ -6,5 +6,5 @@ public interface PecNotificationConnector {
 
     boolean findAndDeletePecNotification(String institutionId, String productId);
 
-    boolean insertPecNotification(PecNotification pecNotification);
+    void insertPecNotification(PecNotification pecNotification);
 }

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
+import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.List;
 import java.util.Objects;
@@ -21,8 +22,12 @@ import java.util.stream.Collectors;
 @Component
 public class PecNotificationConnectorImpl implements PecNotificationConnector {
 
+    private static final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+    private static final Validator validator = validatorFactory.getValidator();
+
     private final PecNotificationRepository repository;
     private final PecNotificationEntityMapper pecNotificationMapper;
+
 
     public PecNotificationConnectorImpl(PecNotificationRepository repository, PecNotificationEntityMapper pecNotificationMapper) {
         this.repository = repository;
@@ -53,30 +58,26 @@ public class PecNotificationConnectorImpl implements PecNotificationConnector {
     }
 
     @Override
-    public boolean insertPecNotification(PecNotification pecNotification){
+    public void insertPecNotification(PecNotification pecNotification){
 
-        PecNotificationEntity pecNotificationEntity = this.pecNotificationMapper.convertToPecNotificationEntity(pecNotification);
+        PecNotificationEntity pecNotificationEntity = pecNotificationMapper.convertToPecNotificationEntity(pecNotification);
 
-        boolean exist = repository.existsByInstitutionIdAndProductId(pecNotificationEntity.getInstitutionId(), pecNotificationEntity.getProductId());
-
-        if (exist){
+        if(repository.existsByInstitutionIdAndProductId(pecNotificationEntity.getInstitutionId(), pecNotificationEntity.getProductId())){
         	log.trace("Cannot insert the PecNotification: {}, as it already exists in the collection", pecNotification.toString());
-            return true;
+            return;
         }
 
-        try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
-            Set<ConstraintViolation<PecNotificationEntity>> validations = factory.getValidator().validate(pecNotificationEntity);
-            if (!validations.isEmpty()){
-                log.warn("Cannot insert the PecNotification: {}, ", validations.stream()
-                        .map(v -> String.format("%s %s", v.getPropertyPath().toString(), v.getMessage()))
-                        .collect(Collectors.joining(",")));
-                return true;
-            }
-        } catch (Exception ignored) { }
+
+        Set<ConstraintViolation<PecNotificationEntity>> validations = validator.validate(pecNotificationEntity);
+        if (!validations.isEmpty()){
+            log.warn("Cannot insert the PecNotification: {}, ", validations.stream()
+                    .map(v -> String.format("%s %s", v.getPropertyPath().toString(), v.getMessage()))
+                    .collect(Collectors.joining(",")));
+            return;
+        }
 
         repository.insert(pecNotificationEntity);
         log.trace("Inserted PecNotification: {}", pecNotification.toString());
-        return true;
     }
 
 }

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
@@ -8,6 +8,7 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Sharded;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
 
@@ -27,6 +28,7 @@ public class PecNotificationEntity {
     @NotNull
     private Integer moduleDayOfTheEpoch;
     @NotNull
+    @Email
     private String digitalAddress;
 
     private Instant createdAt;

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
@@ -5,12 +5,11 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.types.ObjectId;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Sharded;
 
+import javax.validation.constraints.NotNull;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 
 @Data
 @NoArgsConstructor
@@ -21,9 +20,13 @@ public class PecNotificationEntity {
 
     @BsonId
     private ObjectId id;
+    @NotNull
     private String institutionId;
+    @NotNull
     private String productId;
+    @NotNull
     private Integer moduleDayOfTheEpoch;
+    @NotNull
     private String digitalAddress;
 
     private Instant createdAt;

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
@@ -45,6 +45,8 @@ class PecNotificationConnectorImplTest {
         pecNotificationEntity = new PecNotificationEntity();
         pecNotificationEntity.setInstitutionId(institutionId);
         pecNotificationEntity.setProductId(productId);
+        pecNotificationEntity.setDigitalAddress("digitalAddress");
+        pecNotificationEntity.setModuleDayOfTheEpoch(1);
         pecNotification = new PecNotification();
     }
 

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.PecNotificationEntityMapper;
 import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -101,7 +102,18 @@ class PecNotificationConnectorImplTest {
 
         assertTrue(result);
         verify(repository, never()).insert(pecNotificationEntity);
-        
+    }
+
+    @Test
+    @DisplayName("PecNotification is not saved because some mandatory fields misses")
+    void insertPecNotification_someValueMissing() {
+        when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(new PecNotificationEntity());
+        when(repository.existsByInstitutionIdAndProductId(any(), any())).thenReturn(false);
+
+        boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
+
+        assertTrue(result);
+        verify(repository, never()).insert(pecNotificationEntity);
     }
 	
 }

--- a/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
+++ b/apps/institution-ms/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
@@ -45,7 +45,7 @@ class PecNotificationConnectorImplTest {
         pecNotificationEntity = new PecNotificationEntity();
         pecNotificationEntity.setInstitutionId(institutionId);
         pecNotificationEntity.setProductId(productId);
-        pecNotificationEntity.setDigitalAddress("digitalAddress");
+        pecNotificationEntity.setDigitalAddress("digitalAddress@test.com");
         pecNotificationEntity.setModuleDayOfTheEpoch(1);
         pecNotification = new PecNotification();
     }
@@ -89,9 +89,8 @@ class PecNotificationConnectorImplTest {
         when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(pecNotificationEntity);
         when(repository.existsByInstitutionIdAndProductId(any(), any())).thenReturn(false);
 
-        boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
+        pecNotificationConnector.insertPecNotification(pecNotification);
 
-        assertTrue(result);
         verify(repository, times(1)).insert(pecNotificationEntity);
     }
 
@@ -100,9 +99,8 @@ class PecNotificationConnectorImplTest {
         when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(pecNotificationEntity);
         when(repository.existsByInstitutionIdAndProductId(any(), any())).thenReturn(true);
 
-        boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
+        pecNotificationConnector.insertPecNotification(pecNotification);
 
-        assertTrue(result);
         verify(repository, never()).insert(pecNotificationEntity);
     }
 
@@ -112,9 +110,8 @@ class PecNotificationConnectorImplTest {
         when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(new PecNotificationEntity());
         when(repository.existsByInstitutionIdAndProductId(any(), any())).thenReturn(false);
 
-        boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
+        pecNotificationConnector.insertPecNotification(pecNotification);
 
-        assertTrue(result);
         verify(repository, never()).insert(pecNotificationEntity);
     }
 	

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -92,9 +92,7 @@ public class OnboardingServiceImpl implements OnboardingService {
                     createdAtOnboarding, institutionSendMailConfig.getProducts().get(productId)));
             pecNotification.setDigitalAddress(digitalAddress);
 
-            if (!pecNotificationConnector.insertPecNotification(pecNotification)) {
-                throw new InvalidRequestException(INVALID_INSERT_PEC_NOTIFICATION_ERROR.getMessage(), INVALID_INSERT_PEC_NOTIFICATION_ERROR.getCode());
-            }
+            pecNotificationConnector.insertPecNotification(pecNotification);
         }
 
     }

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -149,7 +149,7 @@ class OnboardingServiceImplTest {
         institution.setOnboarding(List.of(onboarding, dummyOnboarding()));
         institution.setInstitutionType(InstitutionType.PA);
 
-        when(pecNotificationConnector.insertPecNotification(any(PecNotification.class))).thenReturn(true);
+        doNothing().when(pecNotificationConnector).insertPecNotification(any(PecNotification.class));
         when(institutionConnector.findById(institution.getId())).thenReturn(institution);
         when(institutionSendMailConfig.getPecNotificationDisabled()).thenReturn(false);
         when(institutionSendMailConfig.getProducts()).thenReturn(Map.of(onboarding.getProductId(),30));
@@ -290,7 +290,7 @@ class OnboardingServiceImplTest {
         token.setStatus(onboarding.getStatus());
         token.setContractSigned(onboarding.getContract());
 
-        when(pecNotificationConnector.insertPecNotification(any(PecNotification.class))).thenReturn(true);
+        doNothing().when(pecNotificationConnector).insertPecNotification(any(PecNotification.class));
         when(institutionConnector.findById(institution.getId())).thenReturn(institution);
         when(institutionConnector.findAndUpdate(any(), any(), any(), any())).thenReturn(institution);
         when(institutionSendMailConfig.getPecNotificationDisabled()).thenReturn(false);
@@ -381,7 +381,7 @@ class OnboardingServiceImplTest {
         when(institutionSendMailConfig.getPecNotificationDisabled()).thenReturn(false);
         when(institutionSendMailConfig.getProducts()).thenReturn(products);
         when(institutionSendMailConfig.getEpochDatePecNotification()).thenReturn("2024-01-01");
-        when(pecNotificationConnector.insertPecNotification(any())).thenReturn(true);
+        doNothing().when(pecNotificationConnector).insertPecNotification(any(PecNotification.class));
 
         // Act
         onboardingServiceImpl.insertPecNotification(institutionId, productId, digitalAddress, createdAtOnboarding);

--- a/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImpl.java
+++ b/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImpl.java
@@ -122,7 +122,7 @@ public class InstitutionSendMailScheduledServiceImpl implements InstitutionSendM
             return Uni.createFrom().voidItem();
         }
         if(Objects.isNull(pecNotification.getDigitalAddress())) {
-            log.warn(String.format("Mail sent for institution %s and product %s", pecNotification.getInstitutionId(), pecNotification.getProductId()));
+            log.warn(String.format("Mail did not send for institution %s and product %s because digitalAddress is empty!", pecNotification.getInstitutionId(), pecNotification.getProductId()));
             return Uni.createFrom().voidItem();
         }
 

--- a/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImpl.java
+++ b/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImpl.java
@@ -121,6 +121,10 @@ public class InstitutionSendMailScheduledServiceImpl implements InstitutionSendM
         if(dayDifference <= 0) {
             return Uni.createFrom().voidItem();
         }
+        if(Objects.isNull(pecNotification.getDigitalAddress())) {
+            log.warn(String.format("Mail sent for institution %s and product %s", pecNotification.getInstitutionId(), pecNotification.getProductId()));
+            return Uni.createFrom().voidItem();
+        }
 
         if (sendFirstMail(dayDifference, pecNotification.getProductId())) {
             Product product = productService.getProduct(pecNotification.getProductId());

--- a/infra/container_apps/institution-send-mail-scheduler/main.tf
+++ b/infra/container_apps/institution-send-mail-scheduler/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_container_app_job" "container_app_job_institution_send_mail_sc
   workload_profile_name        = var.workload_profile_name
 
   replica_timeout_in_seconds = 7200
-  replica_retry_limit        = 0
+  replica_retry_limit        = 0 #we avoid to run more times causing multiple send mails
 
   dynamic "schedule_trigger_config" {
     for_each = var.schedule_trigger_config

--- a/infra/container_apps/institution-send-mail-scheduler/main.tf
+++ b/infra/container_apps/institution-send-mail-scheduler/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_container_app_job" "container_app_job_institution_send_mail_sc
   workload_profile_name        = var.workload_profile_name
 
   replica_timeout_in_seconds = 7200
-  replica_retry_limit        = 30
+  replica_retry_limit        = 0
 
   dynamic "schedule_trigger_config" {
     for_each = var.schedule_trigger_config


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* **Added Validation**: Implemented @NotNull annotations for mandatory fields in PecNotificationEntity and enforced validation logic to ensure required data is present before processing.
* **Updated Retry Settings**: Modified Terraform configuration to set replica_retry_limit to 0, preventing automatic retries when jobs fail.
* **Service Layer Improvements**: Updated service to skip mail sending if digitalAddress is missing, ensuring only valid notifications are processed.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request strengthens data integrity of digitalAddress, optimizes job execution behavior, and ensures robust application performance through comprehensive validation and configuration adjustments.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.