### PR TITLE
[SELC-6298] feat: added product title as email subject prefix

### DIFF
--- a/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/MailService.java
+++ b/apps/institution-send-mail-scheduler/src/main/java/it/pagopa/selfcare/institution/service/MailService.java
@@ -7,5 +7,6 @@ import java.util.Map;
 
 public interface MailService {
 
-    Uni<Void> sendMail(List<String> destinationMail, String templateName, Map<String, String> mailParameters);
+    Uni<Void> sendMail(List<String> destinationMail, String templateName, Map<String, String> mailParameters, String prefixSubject);
+
 }

--- a/apps/institution-send-mail-scheduler/src/test/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImplTest.java
+++ b/apps/institution-send-mail-scheduler/src/test/java/it/pagopa/selfcare/institution/service/InstitutionSendMailScheduledServiceImplTest.java
@@ -81,7 +81,7 @@ class InstitutionSendMailScheduledServiceImplTest {
         UniAssertSubscriber<Void> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertNotTerminated();
         Mockito.verify(mailService, Mockito.atLeast(4))
-                .sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap());
+                .sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap(), Mockito.any());
     }
 
 
@@ -108,7 +108,7 @@ class InstitutionSendMailScheduledServiceImplTest {
         UniAssertSubscriber<Void> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
         subscriber.assertCompleted();
         Mockito.verify(mailService, Mockito.times(0))
-                .sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap());
+                .sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyString());
     }
 
     @Test
@@ -132,7 +132,7 @@ class InstitutionSendMailScheduledServiceImplTest {
         Product product = new Product();
         product.setTitle("prod-io");
         when(productService.getProduct("product-id")).thenReturn(product);
-        Mockito.doThrow(new RuntimeException("Mail send failed")).when(mailService).sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap());
+        Mockito.doThrow(new RuntimeException("Mail send failed")).when(mailService).sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyString());
 
         // Execute
         Uni<Boolean> result = service.runQueryAndSendNotification(moduleDayOfTheEpoch, page, "productId");
@@ -158,7 +158,7 @@ class InstitutionSendMailScheduledServiceImplTest {
         UniAssertSubscriber<Boolean> subscriber = result.subscribe().withSubscriber(UniAssertSubscriber.create());
 
         // Verify
-        Mockito.verify(mailService, Mockito.never()).sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap());
+        Mockito.verify(mailService, Mockito.never()).sendMail(Mockito.anyList(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyString());
         subscriber.assertCompleted();
     }
 

--- a/apps/institution-send-mail-scheduler/src/test/java/it/pagopa/selfcare/institution/service/MailServiceImplTest.java
+++ b/apps/institution-send-mail-scheduler/src/test/java/it/pagopa/selfcare/institution/service/MailServiceImplTest.java
@@ -56,7 +56,7 @@ class MailServiceImplTest {
         Mockito.when(objectMapper.readValue(Mockito.anyString(), Mockito.eq(MailTemplate.class)))
                 .thenReturn(mailTemplate);
         // When
-        mailService.sendMail(destinationMails, "templateName", mailParameters);
+        mailService.sendMail(destinationMails, "templateName", mailParameters, null);
 
         // Then
         ArgumentCaptor<Mail> mailCaptor = ArgumentCaptor.forClass(Mail.class);
@@ -72,7 +72,7 @@ class MailServiceImplTest {
         // Then
         assertThrows(GenericException.class, () -> {
             // When
-            mailService.sendMail(Collections.singletonList("recipient@example.com"), "templateName", Collections.singletonMap("name", "John Doe"));
+            mailService.sendMail(Collections.singletonList("recipient@example.com"), "templateName", Collections.singletonMap("name", "John Doe"), null);
         });
     }
 }


### PR DESCRIPTION
#### List of Changes

- Added product title as email subject prefix, using the same format as onboarding emails

#### Motivation and Context

When an organization subscribes to multiple products and receives multiple verification emails, the subject can now be distinguished by the product title.

#### How Has This Been Tested?

Tested locally using a test email

#### Screenshots:

- Pre: 
<img width="693" alt="image" src="https://github.com/user-attachments/assets/461cd619-c7e8-43e5-9e0c-233a7a7a93c9" />

- Post:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/43bef96d-5334-4f5e-86b5-2f702eb54c81" />

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.