### PR TITLE
[SELC-6737] Increased temporarily institution-send-mail-scheduler replica timeout to 8 hours

### DIFF
--- a/infra/container_apps/institution-send-mail-scheduler/main.tf
+++ b/infra/container_apps/institution-send-mail-scheduler/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_container_app_job" "container_app_job_institution_send_mail_sc
   container_app_environment_id = data.azurerm_container_app_environment.container_app_environment.id
   workload_profile_name        = var.workload_profile_name
 
-  replica_timeout_in_seconds = 7200
+  replica_timeout_in_seconds = 28800
   replica_retry_limit        = 0 #we avoid to run more times causing multiple send mails
 
   dynamic "schedule_trigger_config" {


### PR DESCRIPTION
#### List of Changes

- Increased temporarily institution-send-mail-scheduler replica timeout to 8 hours

#### Motivation and Context

Prevents the job from being killed after 2 hours on days when a lot of emails need to be sent

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.