### PR TITLE
[SELC-6828] Exposed a new boolean test field in getInstitutions

### DIFF
--- a/apps/institution-ms/app/src/main/docs/openapi.json
+++ b/apps/institution-ms/app/src/main/docs/openapi.json
@@ -3392,6 +3392,9 @@
           "taxCode" : {
             "type" : "string"
           },
+          "test" : {
+            "type" : "boolean"
+          },
           "updatedAt" : {
             "type" : "string",
             "format" : "date-time"

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
@@ -50,5 +50,6 @@ public class Institution {
     private String parentDescription;
     private PaAttributes paAttributes;
     private boolean delegation;
+    private Boolean test;
 
 }

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/InstitutionEntity.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/InstitutionEntity.java
@@ -1,8 +1,8 @@
 package it.pagopa.selfcare.mscore.connector.dao.model;
 
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.*;
 import it.pagopa.selfcare.mscore.constant.Origin;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import lombok.Data;
 import lombok.experimental.FieldNameConstants;
 import org.springframework.data.annotation.Id;
@@ -57,5 +57,6 @@ public class InstitutionEntity {
     private String rootParentId;
     private PaAttributesEntity paAttributes;
     private boolean delegation;
+    private Boolean test;
 
 }

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
@@ -1,10 +1,10 @@
 package it.pagopa.selfcare.mscore.core.util;
 
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.model.institution.*;
 import it.pagopa.selfcare.mscore.model.onboarding.Contract;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -46,7 +46,7 @@ public class TestUtils {
                 "The characteristics of someone or something", institutionType, "42 Main St", "42 Main St", "21654",
                 "TaxCode","ivass", "city", "county", "country", "istatCode", billing, onboarding, geographicTaxonomies, attributes, paymentServiceProvider,
                 new DataProtectionOfficer(), null, null, "START - setupCommonData", "START - setupCommonData",
-                "START - setupCommonData", true, OffsetDateTime.now(), OffsetDateTime.now(), null, null, null, null, new PaAttributes(),false);
+                "START - setupCommonData", true, OffsetDateTime.now(), OffsetDateTime.now(), null, null, null, null, new PaAttributes(),false,null);
     }
 
     public static OnboardingRequest dummyOnboardingRequest(Billing billing, Contract contract, InstitutionUpdate institutionUpdate){

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
@@ -48,5 +48,6 @@ public class InstitutionResponse {
     private OffsetDateTime updatedAt;
     private boolean delegation;
     private String logo;
+    private Boolean test;
 
 }


### PR DESCRIPTION
#### List of Changes

- Added Boolean test field in InstitutionResponse, Institution and InstitutionEntity models

#### Motivation and Context

Requested a way to identify institutions used for testing purposes: the field if present on db is returned by getInstitutions otherwise the field is hidden. It is up to the caller to create filter logic on the field.

#### How Has This Been Tested?

- Local tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.