### PR TITLE
[SELC-7196] feat: added field istatCode in non-IPA createInstitution* request

### DIFF
--- a/apps/institution-ms/app/src/main/docs/openapi.json
+++ b/apps/institution-ms/app/src/main/docs/openapi.json
@@ -2796,6 +2796,9 @@
           "existsInRegistry" : {
             "type" : "boolean"
           },
+          "istatCode" : {
+            "type" : "string"
+          },
           "taxId" : {
             "type" : "string"
           }
@@ -3377,6 +3380,9 @@
             "type" : "string",
             "enum" : [ "AS", "CON", "GPU", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
+          "istatCode" : {
+            "type" : "string"
+          },
           "onboarding" : {
             "type" : "array",
             "items" : {
@@ -3952,6 +3958,9 @@
             "type" : "string"
           },
           "injectionInstitutionType" : {
+            "type" : "string"
+          },
+          "istatCode" : {
             "type" : "string"
           },
           "taxCode" : {

--- a/apps/institution-ms/app/src/test/resources/features/institution.feature
+++ b/apps/institution-ms/app/src/test/resources/features/institution.feature
@@ -524,15 +524,17 @@ Feature: Institution
     And The following request body:
       """
       {
-        "taxCode": "06068501219"
+        "taxCode": "06068501219",
+        "istatCode": "06068501219"
       }
       """
     When I send a POST request to "/institutions/from-anac"
     Then The status code is 201
     And The response body contains:
-      | taxCode  | 06068501219 |
-      | origin   | ANAC        |
-      | originId | 06068501219 |
+      | taxCode   | 06068501219 |
+      | istatCode | 06068501219 |
+      | origin    | ANAC        |
+      | originId  | 06068501219 |
     And The response body contains field "id"
 
   Scenario: TaxCode not found from ANAC
@@ -553,15 +555,17 @@ Feature: Institution
     And The following request body:
       """
       {
-        "taxCode": "06068501219"
+        "taxCode": "06068501219",
+        "istatCode": "06068501219"
       }
       """
     When I send a POST request to "/institutions/from-anac"
     Then The status code is 201
     And The response body contains:
-      | taxCode  | 06068501219 |
-      | origin   | ANAC        |
-      | originId | 06068501219 |
+      | taxCode   | 06068501219 |
+      | istatCode | 06068501219 |
+      | origin    | ANAC        |
+      | originId  | 06068501219 |
     And The response body contains field "id"
     And The response body doesn't contain field "supportEmail"
     # UPDATE
@@ -570,13 +574,15 @@ Feature: Institution
       """
       {
         "taxCode": "06068501219",
-        "supportEmail": "test@pec.it"
+        "supportEmail": "test@pec.it",
+        "istatCode": "06068501220"
       }
       """
     When I send a POST request to "/institutions/from-anac"
     Then The status code is 201
     And The response body contains:
       | taxCode      | 06068501219 |
+      | istatCode    | 06068501220 |
       | origin       | ANAC        |
       | originId     | 06068501219 |
       | supportEmail | test@pec.it |
@@ -590,15 +596,17 @@ Feature: Institution
     And The following request body:
       """
       {
-        "originId": "A044S"
+        "originId": "A044S",
+        "istatCode": "06068501219"
       }
       """
     When I send a POST request to "/institutions/from-ivass"
     Then The status code is 201
     And The response body contains:
-      | taxCode  | 00409920584 |
-      | origin   | IVASS       |
-      | originId | A044S       |
+      | taxCode   | 00409920584 |
+      | istatCode | 06068501219 |
+      | origin    | IVASS       |
+      | originId  | A044S       |
     And The response body contains field "id"
 
   Scenario: originId not found from IVASS
@@ -619,15 +627,17 @@ Feature: Institution
     And The following request body:
       """
       {
-        "originId": "A044S"
+        "originId": "A044S",
+        "istatCode": "06068501219"
       }
       """
     When I send a POST request to "/institutions/from-ivass"
     Then The status code is 201
     And The response body contains:
-      | taxCode  | 00409920584 |
-      | origin   | IVASS       |
-      | originId | A044S       |
+      | taxCode   | 00409920584 |
+      | istatCode | 06068501219 |
+      | origin    | IVASS       |
+      | originId  | A044S       |
     And The response body contains field "id"
     And The response body doesn't contain field "supportEmail"
     # UPDATE
@@ -636,13 +646,15 @@ Feature: Institution
       """
       {
         "originId": "A044S",
-        "supportEmail": "test@pec.it"
+        "supportEmail": "test@pec.it",
+        "istatCode": "06068501220"
       }
       """
     When I send a POST request to "/institutions/from-ivass"
     Then The status code is 201
     And The response body contains:
       | taxCode      | 00409920584 |
+      | istatCode    | 06068501220 |
       | origin       | IVASS       |
       | originId     | A044S       |
       | supportEmail | test@pec.it |
@@ -678,6 +690,7 @@ Feature: Institution
         {
           "injectionInstitutionType": "Test",
           "taxCode": "01501320442",
+          "istatCode": "06068501219",
           "description": "Test description"
         }
       """
@@ -685,6 +698,7 @@ Feature: Institution
     Then The status code is 201
     And The response body contains:
       | taxCode         | 01501320442 |
+      | istatCode       | 06068501219 |
       | origin          | INFOCAMERE  |
       | originId        | 01501320442 |
       | institutionType | PG          |
@@ -730,15 +744,17 @@ Feature: Institution
     And The following request body:
       """
       {
-        "taxCode": "01501320442"
+        "taxCode": "01501320442",
+        "istatCode": "06068501219"
       }
       """
     When I send a POST request to "/institutions/from-infocamere"
     Then The status code is 201
     And The response body contains:
-      | taxCode  | 01501320442 |
-      | origin   | INFOCAMERE  |
-      | originId | 01501320442 |
+      | taxCode   | 01501320442 |
+      | istatCode | 06068501219 |
+      | origin    | INFOCAMERE  |
+      | originId  | 01501320442 |
     And The response body contains field "id"
 
   @RemoveInstitutionIdAfterScenario
@@ -765,15 +781,17 @@ Feature: Institution
     And The following request body:
       """
       {
-        "taxCode": "01501320442"
+        "taxCode": "01501320442",
+        "istatCode": "06068501219"
       }
       """
     When I send a POST request to "/institutions/from-infocamere"
     Then The status code is 201
     And The response body contains:
-      | taxCode  | 01501320442 |
-      | origin   | INFOCAMERE  |
-      | originId | 01501320442 |
+      | taxCode   | 01501320442 |
+      | istatCode | 06068501219 |
+      | origin    | INFOCAMERE  |
+      | originId  | 01501320442 |
     And The response body contains field "id"
     And The response body doesn't contain field "description"
     # UPDATE
@@ -782,6 +800,7 @@ Feature: Institution
       """
       {
         "taxCode": "01501320442",
+        "istatCode": "06068501220",
         "description": "test description"
       }
       """
@@ -789,6 +808,7 @@ Feature: Institution
     Then The status code is 201
     And The response body contains:
       | taxCode     | 01501320442      |
+      | istatCode   | 06068501220      |
       | origin      | INFOCAMERE       |
       | originId    | 01501320442      |
       | description | test description |
@@ -804,15 +824,18 @@ Feature: Institution
     And The following request body:
       """
       {
-        "taxCode": "123456789"
+        "taxCode": "123456789",
+        "istatCode": "06068501219"
+
       }
       """
     When I send a POST request to "/institutions"
     Then The status code is 201
     And The response body contains:
-      | taxCode  | 123456789      |
-      | origin   | SELC           |
-      | originId | SELC_123456789 |
+      | taxCode   | 123456789      |
+      | istatCode | 06068501219 |
+      | origin    | SELC           |
+      | originId  | SELC_123456789 |
     And The response body contains field "id"
 
   @RemoveInstitutionIdAfterScenario
@@ -862,6 +885,7 @@ Feature: Institution
       """
         {
           "taxId": "0987654321",
+          "istatCode": "06068501219",
           "description": "Test PG Institution",
           "existsInRegistry": false
         }
@@ -870,6 +894,7 @@ Feature: Institution
     Then The status code is 201
     And The response body contains:
       | taxCode         | 0987654321          |
+      | istatCode       | 06068501219         |
       | origin          | ADE                 |
       | originId        | 0987654321          |
       | institutionType | PG                  |
@@ -883,6 +908,7 @@ Feature: Institution
       """
         {
           "taxId": "01501320442",
+          "istatCode": "06068501219",
           "description": "Test PG Institution",
           "existsInRegistry": true
         }
@@ -891,6 +917,7 @@ Feature: Institution
     Then The status code is 201
     And The response body contains:
       | taxCode         | 01501320442 |
+      | istatCode       | 06068501219 |
       | origin          | INFOCAMERE  |
       | originId        | 01501320442 |
       | institutionType | PG          |

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -35,7 +35,7 @@ public interface InstitutionService {
 
     Institution createInstitutionFromInfocamere(Institution institution);
 
-    Institution createPgInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser);
+    Institution createPgInstitution(String taxId, String description, String istatCode, boolean existsInRegistry, SelfCareUser selfCareUser);
 
     Institution createInstitution(Institution institution);
 

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -132,6 +132,7 @@ public class InstitutionServiceImpl implements InstitutionService {
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
                 .taxCode(institution.getTaxCode())
                 .description(institution.getDescription())
+                .istatCode(institution.getIstatCode())
                 .build());
     }
 
@@ -140,6 +141,7 @@ public class InstitutionServiceImpl implements InstitutionService {
         return createInstitutionStrategyFactory.createInstitutionStrategy(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode(institution.getTaxCode())
+                        .istatCode(institution.getIstatCode())
                         .subunitCode(institution.getSubunitCode())
                         .subunitType(Optional.ofNullable(institution.getSubunitType())
                                 .map(InstitutionPaSubunitType::valueOf)
@@ -160,6 +162,7 @@ public class InstitutionServiceImpl implements InstitutionService {
                                 .orElse(null))
                         .supportEmail(institution.getSupportEmail())
                         .supportPhone(institution.getSupportPhone())
+                        .istatCode(institution.getIstatCode())
                         .build());
     }
 
@@ -170,6 +173,7 @@ public class InstitutionServiceImpl implements InstitutionService {
                         .ivassCode(institution.getOriginId())
                         .supportEmail(institution.getSupportEmail())
                         .supportPhone(institution.getSupportPhone())
+                        .istatCode(institution.getIstatCode())
                         .build());
     }
 
@@ -179,6 +183,7 @@ public class InstitutionServiceImpl implements InstitutionService {
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
                 .taxCode(institution.getTaxCode())
                 .description(institution.getDescription())
+                .istatCode(institution.getIstatCode())
                 .build());
     }
 
@@ -212,13 +217,13 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public Institution createPgInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser) {
+    public Institution createPgInstitution(String taxId, String description, String istatCode, boolean existsInRegistry, SelfCareUser selfCareUser) {
         return institutionConnector.findByExternalId(taxId)
-                .orElseGet(() -> createNewInstitution(taxId, description, existsInRegistry, selfCareUser));
+                .orElseGet(() -> createNewInstitution(taxId, description, istatCode, existsInRegistry, selfCareUser));
 
     }
 
-    private Institution createNewInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser) {
+    private Institution createNewInstitution(String taxId, String description, String istatCode, boolean existsInRegistry, SelfCareUser selfCareUser) {
         Institution newInstitution = new Institution();
         newInstitution.setExternalId(taxId);
         newInstitution.setDescription(description);
@@ -226,6 +231,7 @@ public class InstitutionServiceImpl implements InstitutionService {
         newInstitution.setTaxCode(taxId);
         newInstitution.setCreatedAt(OffsetDateTime.now());
         newInstitution.setOriginId(taxId);
+        newInstitution.setIstatCode(istatCode);
 
         if (existsInRegistry) {
             if (coreConfig.isInfoCamereEnable()) {

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyAnac.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyAnac.java
@@ -41,6 +41,8 @@ public class CreateInstitutionStrategyAnac extends CreateInstitutionStrategyComm
 
             setContacts(strategyInput, institution);
 
+            setIstatCode(strategyInput, institution);
+
         } else {
             //Institution exists but other fields could be updated
             institution = institutions.get(0);

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyCommon.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyCommon.java
@@ -32,8 +32,15 @@ public class CreateInstitutionStrategyCommon {
         if (strategyInput.getDescription() != null) {
             toSavedOrUpdate.setDescription(strategyInput.getDescription());
         }
+        setIstatCode(strategyInput, toSavedOrUpdate);
         setContacts(strategyInput, toSavedOrUpdate);
         toSavedOrUpdate.setUpdatedAt(OffsetDateTime.now());
+    }
+
+    protected static void setIstatCode(CreateInstitutionStrategyInput strategyInput, Institution toSavedOrUpdate) {
+        if (strategyInput.getIstatCode() != null) {
+            toSavedOrUpdate.setIstatCode(strategyInput.getIstatCode());
+        }
     }
 
     protected static void setContacts(CreateInstitutionStrategyInput strategyInput, Institution toSavedOrUpdate) {

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyInfocamere.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyInfocamere.java
@@ -64,6 +64,8 @@ public class CreateInstitutionStrategyInfocamere extends CreateInstitutionStrate
             toSavedOrUpdate.setUpdatedAt(OffsetDateTime.now());
         }
 
+        setIstatCode(strategyInput, toSavedOrUpdate);
+
         try {
             return institutionConnector.save(toSavedOrUpdate);
         } catch (Exception e) {

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIvass.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIvass.java
@@ -41,6 +41,8 @@ public class CreateInstitutionStrategyIvass extends CreateInstitutionStrategyCom
 
             setContacts(strategyInput, institution);
 
+            setIstatCode(strategyInput, institution);
+
         } else {
             //Institution exists but other fields could be updated
             institution = institutions.get(0);

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
@@ -84,7 +84,7 @@ public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommo
     private Institution searchInstitutionOnInfocamere(CreateInstitutionStrategyInput strategyInput){
         try {
             NationalRegistriesProfessionalAddress professionalAddress = partyRegistryProxyConnector.getLegalAddress(strategyInput.getTaxCode());
-            return getInstitutionFromInfocamere(strategyInput.getTaxCode(), strategyInput.getDescription(), professionalAddress);
+            return getInstitutionFromInfocamere(strategyInput.getTaxCode(), strategyInput.getDescription(), strategyInput.getIstatCode(), professionalAddress);
         } catch (MsCoreException ex) {
             if(ex.getCode().equalsIgnoreCase(String.valueOf(HttpStatus.NOT_FOUND.value()))) {
                 log.warn("Institution with taxCode {} not found in registry INFOCAMERE", MaskDataUtils.maskString(strategyInput.getTaxCode()));
@@ -94,7 +94,7 @@ public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommo
         }
     }
 
-    private Institution getInstitutionFromInfocamere(String taxCode, String description, NationalRegistriesProfessionalAddress professionalAddress) {
+    private Institution getInstitutionFromInfocamere(String taxCode, String description, String istatCode, NationalRegistriesProfessionalAddress professionalAddress) {
         Institution newInstitution = institutionMapper.fromProfessionalAddress(professionalAddress);
         newInstitution.setTaxCode(taxCode);
         newInstitution.setDescription(description);
@@ -105,6 +105,7 @@ public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommo
         }else{
             newInstitution.setInstitutionType(InstitutionType.PG);
         }
+        newInstitution.setIstatCode(istatCode);
         newInstitution.setOriginId(taxCode);
         newInstitution.setCreatedAt(OffsetDateTime.now());
         newInstitution.setImported(true);

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyRaw.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyRaw.java
@@ -37,6 +37,7 @@ public class CreateInstitutionStrategyRaw extends CreateInstitutionStrategyCommo
             }
             institution.setCreatedAt(OffsetDateTime.now());
             setContacts(strategyInput, institution);
+            setIstatCode(strategyInput, institution);
         } else {
             institution = institutions.get(0);
             setUpdatedFields(strategyInput, institution);

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
@@ -21,4 +21,5 @@ public class CreateInstitutionStrategyInput {
     private InstitutionType institutionType;
     private String supportEmail;
     private String supportPhone;
+    private String istatCode;
 }

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -233,7 +233,7 @@ class InstitutionServiceImplTest {
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitutionNotFoundInstitution() {
@@ -251,14 +251,14 @@ class InstitutionServiceImplTest {
         when(partyRegistryProxyConnector.getLegalAddress(taxId)).thenReturn(professionalAddress);
         when(institutionConnector.save(any())).thenReturn(institution);
         when(coreConfig.isInfoCamereEnable()).thenReturn(true);
-        Institution response = institutionServiceImpl.createPgInstitution(taxId, "42", true, mock(SelfCareUser.class));
+        Institution response = institutionServiceImpl.createPgInstitution(taxId, "42", "42",true, mock(SelfCareUser.class));
         assertEquals(response.getTaxCode(), taxId);
         verify(institutionConnector).findByExternalId(any());
         verify(institutionConnector).save(any());
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitutionFoundedInstitution() {
@@ -268,7 +268,7 @@ class InstitutionServiceImplTest {
         institution.setTaxCode(taxId);
         institution.setExternalId(taxId);
         when(institutionConnector.findByExternalId(taxId)).thenReturn(Optional.of(institution));
-        Institution response = institutionServiceImpl.createPgInstitution(taxId, "42", true, mock(SelfCareUser.class));
+        Institution response = institutionServiceImpl.createPgInstitution(taxId, "42", "42",true, mock(SelfCareUser.class));
         assertEquals(response.getId(), institution.getId());
         assertEquals(response.getTaxCode(), taxId);
         assertEquals(response.getExternalId(), taxId);
@@ -389,7 +389,7 @@ class InstitutionServiceImplTest {
         assertTrue(institutionsResult.isEmpty());
     }
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitution4() {
@@ -402,12 +402,12 @@ class InstitutionServiceImplTest {
         institutionByLegal.setBusinessTaxId("42");
 
         SelfCareUser selfCareUser = mock(SelfCareUser.class);
-        Institution institutionResult = institutionServiceImpl.createPgInstitution("42", "42", false, selfCareUser);
+        Institution institutionResult = institutionServiceImpl.createPgInstitution("42", "42", "42",false, selfCareUser);
         assertSame(institution, institutionResult);
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitution2() {
@@ -423,23 +423,23 @@ class InstitutionServiceImplTest {
         when(institutionConnector.findByExternalId(any())).thenReturn(Optional.empty());
 
         SelfCareUser selfCareUser = mock(SelfCareUser.class);
-        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42", true, selfCareUser));
+        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42", "42",true, selfCareUser));
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitution5() {
         when(institutionConnector.findByExternalId(any()))
                 .thenThrow(new ResourceNotFoundException("An error occurred", "START - check institution {} already exists"));
         assertThrows(ResourceNotFoundException.class,
-                () -> institutionServiceImpl.createPgInstitution("42", "42", true, mock(SelfCareUser.class)));
+                () -> institutionServiceImpl.createPgInstitution("42", "42", "42",true, mock(SelfCareUser.class)));
         verify(institutionConnector).findByExternalId(any());
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitution6() {
@@ -452,13 +452,13 @@ class InstitutionServiceImplTest {
         institutionByLegal.setBusinessTaxId("42");
 
         SelfCareUser selfCareUser = mock(SelfCareUser.class);
-        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42", false, selfCareUser));
+        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42","42", false, selfCareUser));
         verify(institutionConnector).save(any());
         verify(institutionConnector).findByExternalId(any());
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitution7() {
@@ -472,11 +472,11 @@ class InstitutionServiceImplTest {
 
         SelfCareUser selfCareUser = mock(SelfCareUser.class);
         assertThrows(ResourceConflictException.class,
-                () -> institutionServiceImpl.createPgInstitution("42", "42", true, selfCareUser));
+                () -> institutionServiceImpl.createPgInstitution("42", "42", "42",true, selfCareUser));
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitution9() {
@@ -491,11 +491,11 @@ class InstitutionServiceImplTest {
         when(institutionConnector.save(any())).thenReturn(institution);
         when(institutionConnector.findByExternalId(any())).thenReturn(Optional.empty());
         SelfCareUser selfCareUser = mock(SelfCareUser.class);
-        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42", true, selfCareUser));
+        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42", "42",true, selfCareUser));
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, boolean, SelfCareUser)}
+     * Method under test: {@link InstitutionServiceImpl#createPgInstitution(String, String, String, boolean, SelfCareUser)}
      */
     @Test
     void testCreatePgInstitution14() {
@@ -510,7 +510,7 @@ class InstitutionServiceImplTest {
         when(institutionConnector.save(any())).thenReturn(institution);
         when(institutionConnector.findByExternalId(any())).thenReturn(Optional.empty());
         SelfCareUser selfCareUser = mock(SelfCareUser.class);
-        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42", false, selfCareUser));
+        assertSame(institution, institutionServiceImpl.createPgInstitution("42", "42", "42", false, selfCareUser));
         verify(institutionConnector).save(any());
         verify(institutionConnector).findByExternalId(any());
     }

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPdaTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPdaTest.java
@@ -109,6 +109,7 @@ public class CreateInstitutionStrategyPdaTest {
         Institution institutionToReturn = new Institution();
         institutionToReturn.setId("id");
         institutionToReturn.setDescription("test");
+        institutionToReturn.setIstatCode("42");
 
         //Given
         when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any(), eq(null)))
@@ -126,6 +127,7 @@ public class CreateInstitutionStrategyPdaTest {
 
         assertThat(actual.getId()).isEqualTo(institutionToReturn.getId());
         assertThat(actual.getDescription()).isEqualTo(institutionToReturn.getDescription());
+        assertThat(actual.getIstatCode()).isEqualTo(institutionToReturn.getIstatCode());
 
         verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any(), eq(null));
         verify(partyRegistryProxyConnector).getCategory(any(), any());
@@ -141,6 +143,7 @@ public class CreateInstitutionStrategyPdaTest {
         Institution institutionToReturn = new Institution();
         institutionToReturn.setId("id");
         institutionToReturn.setDescription("test");
+        institutionToReturn.setIstatCode("42");
 
         NationalRegistriesProfessionalAddress nationalRegistriesProfessionalAddress = new NationalRegistriesProfessionalAddress();
         nationalRegistriesProfessionalAddress.setZipCode("test");
@@ -158,10 +161,12 @@ public class CreateInstitutionStrategyPdaTest {
         Institution actual = strategyFactory.createInstitutionStrategyPda("EC")
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode("test")
+                        .istatCode("42")
                         .build());
 
         assertThat(actual.getId()).isEqualTo(institutionToReturn.getId());
         assertThat(actual.getDescription()).isEqualTo(institutionToReturn.getDescription());
+        assertThat(actual.getIstatCode()).isEqualTo(institutionToReturn.getIstatCode());
 
         verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any(), eq(null));
         verify(partyRegistryProxyConnector).getInstitutionById(any());
@@ -177,6 +182,7 @@ public class CreateInstitutionStrategyPdaTest {
         Institution institutionToReturn = new Institution();
         institutionToReturn.setId("id");
         institutionToReturn.setDescription("test");
+        institutionToReturn.setIstatCode("42");
 
         NationalRegistriesProfessionalAddress nationalRegistriesProfessionalAddress = new NationalRegistriesProfessionalAddress();
         nationalRegistriesProfessionalAddress.setZipCode("test");
@@ -194,10 +200,12 @@ public class CreateInstitutionStrategyPdaTest {
         Institution actual = strategyFactory.createInstitutionStrategyPda("EC")
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode("test")
+                        .istatCode("42")
                         .build());
 
         assertThat(actual.getId()).isEqualTo(institutionToReturn.getId());
         assertThat(actual.getDescription()).isEqualTo(institutionToReturn.getDescription());
+        assertThat(actual.getIstatCode()).isEqualTo(institutionToReturn.getIstatCode());
 
         verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any(), eq(null));
         verify(partyRegistryProxyConnector).getInstitutionById(any());

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyRawTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyRawTest.java
@@ -37,20 +37,23 @@ class CreateInstitutionStrategyRawTest {
     void createInstitutionStrategyRawWithPassedOriginAndOriginId() {
         institution.setOrigin("CUSTOM");
         institution.setOriginId("CUSTOM_taxCode");
+        institution.setIstatCode("CUSTOM_istatCode");
         when(institutionConnector.findByTaxCodeAndSubunitCode("taxCode", null, null)).thenReturn(Collections.emptyList());
         when(institutionConnector.save(institution)).thenReturn(institution);
         Institution response = strategy.createInstitution(CreateInstitutionStrategyInput.builder().taxCode("taxCode").build());
         Assertions.assertEquals("CUSTOM", response.getOrigin());
         Assertions.assertEquals("CUSTOM_taxCode", response.getOriginId());
+        Assertions.assertEquals("CUSTOM_istatCode", response.getIstatCode());
     }
 
     @Test
     void createInstitutionStrategyRawWithDefaultOriginAndOriginId() {
+        institution.setIstatCode("CUSTOM_istatCode");
         when(institutionConnector.findByTaxCodeAndSubunitCode("taxCode", null, null)).thenReturn(Collections.emptyList());
         when(institutionConnector.save(institution)).thenReturn(institution);
         Institution response = strategy.createInstitution(CreateInstitutionStrategyInput.builder().taxCode("taxCode").build());
         Assertions.assertEquals("SELC", response.getOrigin());
         Assertions.assertEquals("SELC_taxCode", response.getOriginId());
-
+        Assertions.assertEquals("CUSTOM_istatCode", response.getIstatCode());
     }
 }

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -145,6 +145,7 @@ class CreateInstitutionStrategyTest {
         institution.setId("id");
         institution.setOrigin(origin);
         institution.setOriginId(originId);
+        institution.setIstatCode("42");
 
         when(institutionConnector.findByOriginAndOriginId(any(), any(), eq(null))). thenReturn(List.of(institution));
         when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
@@ -153,12 +154,14 @@ class CreateInstitutionStrategyTest {
         Institution actual = strategyFactory.createInstitutionStrategyIvass(new Institution())
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .ivassCode(originId)
+                        .istatCode("42")
                         .supportEmail(SUPPORT_EMAIL)
                         .supportPhone(SUPPORT_PHONE)
                         .build());
 
         assertThat(actual.getSupportEmail()).isEqualTo(SUPPORT_EMAIL);
         assertThat(actual.getSupportPhone()).isEqualTo(SUPPORT_PHONE);
+        assertThat(actual.getIstatCode()).isEqualTo(institution.getIstatCode());
         verifyNoInteractions(partyRegistryProxyConnector);
     }
 
@@ -193,6 +196,7 @@ class CreateInstitutionStrategyTest {
 
         Institution institution = new Institution();
         institution.setId("id");
+        institution.setIstatCode("42");
 
         when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any(), eq(null))). thenReturn(List.of(institution));
         when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
@@ -201,6 +205,7 @@ class CreateInstitutionStrategyTest {
         Institution actual = strategyFactory.createInstitutionStrategyAnac(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode(institution.getTaxCode())
+                        .istatCode("42")
                         .supportPhone(SUPPORT_PHONE)
                         .supportEmail(SUPPORT_EMAIL)
                         .build());
@@ -208,6 +213,7 @@ class CreateInstitutionStrategyTest {
         //Then
         assertThat(actual.getTaxCode()).isEqualTo(institution.getTaxCode());
         assertThat(actual.getSubunitCode()).isNull();
+        assertThat(actual.getIstatCode()).isEqualTo(institution.getIstatCode());
         assertThat(actual.getSupportPhone()).isEqualTo(SUPPORT_PHONE);
         assertThat(actual.getSupportEmail()).isEqualTo(SUPPORT_EMAIL);
 
@@ -232,6 +238,7 @@ class CreateInstitutionStrategyTest {
         Institution actual = strategyFactory.createInstitutionStrategyAnac(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode(institution.getTaxCode())
+                        .istatCode("istatCode")
                         .supportPhone(SUPPORT_PHONE)
                         .supportEmail(SUPPORT_EMAIL)
                         .build());
@@ -248,6 +255,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getSubunitType()).isNull();
         assertThat(actual.getSupportPhone()).isEqualTo(SUPPORT_PHONE);
         assertThat(actual.getSupportEmail()).isEqualTo(SUPPORT_EMAIL);
+        assertThat(actual.getIstatCode()).isEqualTo(institution.getIstatCode());
 
         verify(institutionConnector).save(any());
     }
@@ -270,6 +278,7 @@ class CreateInstitutionStrategyTest {
         Institution actual = strategyFactory.createInstitutionStrategyIvass(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode(institution.getTaxCode())
+                        .istatCode("istatCode")
                         .build());
 
         //Then
@@ -282,6 +291,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getSubunitType()).isNull();
         assertThat(actual.getInstitutionType()).isEqualTo(InstitutionType.AS);
         assertThat(actual.getSubunitType()).isNull();
+        assertThat(actual.getIstatCode()).isEqualTo(institution.getIstatCode());
 
         verify(institutionConnector).save(any());
     }
@@ -302,6 +312,7 @@ class CreateInstitutionStrategyTest {
         Institution actual = strategyFactory.createInstitutionStrategy(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode(institution.getTaxCode())
+                        .istatCode("istatCode")
                         .build());
 
         //Then
@@ -314,6 +325,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getSubunitType()).isNull();
         assertThat(actual.getInstitutionType()).isEqualTo(InstitutionType.GSP);
         assertThat(actual.getSubunitType()).isNull();
+        assertThat(actual.getIstatCode()).isEqualTo(institution.getIstatCode());
 
         verify(institutionConnector).save(any());
         verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), any(), eq(null));

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -295,7 +295,7 @@ public class InstitutionController {
     public ResponseEntity<InstitutionResponse> createPgInstitution(@RequestBody @Valid CreatePgInstitutionRequest request,
                                                                    Authentication authentication) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
-        Institution saved = institutionService.createPgInstitution(request.getTaxId(), request.getDescription(), request.isExistsInRegistry(), (SelfCareUser) authentication.getPrincipal());
+        Institution saved = institutionService.createPgInstitution(request.getTaxId(), request.getDescription(), request.getIstatCode(), request.isExistsInRegistry(), (SelfCareUser) authentication.getPrincipal());
         return ResponseEntity.status(HttpStatus.CREATED).body(institutionResourceMapper.toInstitutionResponse(saved));
     }
 

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/CreatePgInstitutionRequest.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/CreatePgInstitutionRequest.java
@@ -13,6 +13,8 @@ public class CreatePgInstitutionRequest {
 
     private String description;
 
+    private String istatCode;
+
     @NotNull
     private boolean existsInRegistry;
 

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
@@ -38,5 +38,6 @@ public class InstitutionRequest {
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
     private boolean delegation;
+    private String istatCode;
 
 }

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/PdaInstitutionRequest.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/PdaInstitutionRequest.java
@@ -14,5 +14,8 @@ public class PdaInstitutionRequest {
     private String taxCode;
 
     private String description;
+
+    private String istatCode;
+
     private BillingRequest billing;
 }

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/TestUtils.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/TestUtils.java
@@ -52,6 +52,7 @@ public class TestUtils {
         institution.setAddress("42 Main St");
         institution.setAttributes(new ArrayList<>());
         institution.setBilling(createSimpleBilling());
+        institution.setIstatCode("42");
 
         institution.setDataProtectionOfficer(createSimpleDataProtectionOfficer());
         institution.setDescription("The characteristics of someone or something");
@@ -78,6 +79,7 @@ public class TestUtils {
         institution.setAddress("42 Main St");
         institution.setAttributes(new ArrayList<>());
         institution.setBilling(createSimpleBilling());
+        institution.setIstatCode("42");
 
         institution.setDataProtectionOfficer(createSimpleDataProtectionOfficer());
         institution.setDescription("The characteristics of someone or something");
@@ -104,6 +106,7 @@ public class TestUtils {
         institution.setAddress("42 Main St");
         institution.setAttributes(new ArrayList<>());
         institution.setBilling(createSimpleBilling());
+        institution.setIstatCode("42");
 
         institution.setDataProtectionOfficer(createSimpleDataProtectionOfficer());
         institution.setDescription("The characteristics of someone or something");
@@ -121,6 +124,24 @@ public class TestUtils {
         institution.setZipCode("21654");
         institution.setShareCapital("Share Capital");
         institution.setRea("Rea");
+
+        return institution;
+    }
+
+    public static Institution createSimpleInstitutionPG() {
+        Institution institution = new Institution();
+        institution.setAddress("42 Main St");
+        institution.setIstatCode("42");
+
+        institution.setDescription("The characteristics of someone or something");
+        institution.setExternalId("42");
+        institution.setId("42");
+        institution.setInstitutionType(InstitutionType.PG);
+        institution.setOriginId("Pg Code");
+        institution.setOrigin(Origin.MOCK.name());
+
+       institution.setTaxCode("Tax Code");
+        institution.setZipCode("21654");
 
         return institution;
     }

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerPdaTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerPdaTest.java
@@ -57,6 +57,7 @@ public class InstitutionControllerPdaTest {
         institutionRequest.setInjectionInstitutionType("EC");
         institutionRequest.setDescription("test ec");
         institutionRequest.setTaxCode("taxCode");
+        institutionRequest.setIstatCode("42");
         String content = objectMapper.writeValueAsString(institutionRequest);
 
         Institution institution = createSimpleInstitutionPda();
@@ -72,7 +73,7 @@ public class InstitutionControllerPdaTest {
                 .perform(requestBuilder);
         actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"attributes\":[],\"imported\":true,\"delegation\":false}"));
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"attributes\":[],\"imported\":true,\"delegation\":false}"));
     }
 
     public static Institution createSimpleInstitutionPda() {
@@ -80,6 +81,7 @@ public class InstitutionControllerPdaTest {
         institution.setAddress("42 Main St");
         institution.setAttributes(new ArrayList<>());
         institution.setBilling(createSimpleBilling());
+        institution.setIstatCode("42");
 
         institution.setDescription("The characteristics of someone or something");
         institution.setExternalId("42");

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -136,7 +136,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}]}"));
+                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}]}"));
     }
 
     @Test
@@ -160,7 +160,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
+                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
     }
 
     @Test
@@ -184,7 +184,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
+                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
     }
 
     @Test
@@ -208,7 +208,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
+                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
     }
 
     @Test
@@ -232,7 +232,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
+                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"delegation\":false}]}"));
     }
 
     @Test
@@ -360,7 +360,7 @@ class InstitutionControllerTest {
                 .perform(requestBuilder);
         actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"1234\",\"subunitType\":\"AOO\",\"delegation\":false}"));
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"1234\",\"subunitType\":\"AOO\",\"delegation\":false}"));
 
         ArgumentCaptor<List<InstitutionGeographicTaxonomies>> captorGeo = ArgumentCaptor.forClass(List.class);
         verify(institutionService, times(1))
@@ -381,6 +381,8 @@ class InstitutionControllerTest {
         institutionRequest.setInstitutionType(InstitutionType.SA);
         institutionRequest.setTaxCode("42");
         institutionRequest.setExternalId("42");
+        institutionRequest.setIstatCode("42");
+
         String content = objectMapper.writeValueAsString(institutionRequest);
 
         Institution institution = TestUtils.createSimpleInstitutionSA();
@@ -396,7 +398,7 @@ class InstitutionControllerTest {
                 .perform(requestBuilder);
         actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"ANAC\",\"originId\":\"ANAC Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"SA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"ANAC\",\"originId\":\"ANAC Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"SA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
     }
 
     /**
@@ -410,6 +412,8 @@ class InstitutionControllerTest {
         institutionRequest.setInstitutionType(InstitutionType.AS);
         institutionRequest.setTaxCode("42");
         institutionRequest.setExternalId("42");
+        institutionRequest.setIstatCode("42");
+
         String content = objectMapper.writeValueAsString(institutionRequest);
 
         Institution institution = TestUtils.createSimpleInstitutionAS();
@@ -425,7 +429,7 @@ class InstitutionControllerTest {
                 .perform(requestBuilder);
         actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"IVASS\",\"originId\":\"IVASS Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"AS\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"IVASS\",\"originId\":\"IVASS Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"AS\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
     }
 
     /**
@@ -439,6 +443,8 @@ class InstitutionControllerTest {
         institutionRequest.setInstitutionType(InstitutionType.PG);
         institutionRequest.setTaxCode("42");
         institutionRequest.setExternalId("42");
+        institutionRequest.setIstatCode("42");
+
         String content = objectMapper.writeValueAsString(institutionRequest);
 
         Institution institution = TestUtils.createSimpleInstitutionPA();
@@ -454,7 +460,7 @@ class InstitutionControllerTest {
                 .perform(requestBuilder);
         actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
     }
 
     /**
@@ -592,7 +598,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
+                                "{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"delegation\":false}"));
     }
 
     /**
@@ -765,6 +771,7 @@ class InstitutionControllerTest {
         institution.setAddress("42 Main St");
         institution.setAttributes(new ArrayList<>());
         institution.setBilling(billing);
+        institution.setIstatCode("42");
         institution.setDataProtectionOfficer(dataProtectionOfficer);
         institution.setDescription("The characteristics of someone or something");
         institution.setDigitalAddress("42 Main St");
@@ -818,7 +825,7 @@ class InstitutionControllerTest {
                 .perform(requestBuilder)
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"imported\":false,\"delegation\":false}"));
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"imported\":false,\"delegation\":false}"));
     }
 
     /**
@@ -1140,7 +1147,8 @@ class InstitutionControllerTest {
         request.setTaxId("taxId");
         request.setExistsInRegistry(true);
         ObjectMapper mapper = new ObjectMapper();
-        when(institutionService.createPgInstitution(any(), any(), anyBoolean(), any())).thenReturn(new Institution());
+        Institution institution = TestUtils.createSimpleInstitutionPG();
+        when(institutionService.createPgInstitution(any(), any(), any(),  anyBoolean(), any())).thenReturn(institution);
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/institutions/pg")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(request))
@@ -1149,7 +1157,8 @@ class InstitutionControllerTest {
                 .build()
                 .perform(requestBuilder)
                 .andExpect(MockMvcResultMatchers.status().isCreated())
-                .andExpect(MockMvcResultMatchers.content().contentType("application/json"));
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Pg Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PG\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"istatCode\":\"42\",\"imported\":false,\"delegation\":false}"));
     }
 
     /**


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- added field istatCode in createInstitutionFromAnac, createPgInstitution, createInstitution, createInstitutionFromInfocamere, createInstitutionFromPda, createInstitutionFromIvass request
- update unit test
- update cucumber integration test 
- update openapi.json 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allow to pass and persist the field istatCode in Institution object for non-IPA entities

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

It was tested locally through swagger, unit tests and cucumber tests.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.