### PR TITLE
[SELC-7720] feat: set productId filter and get institutionType, origin and originId from onboarding if product filter is present

### DIFF
--- a/apps/institution-ms/app/src/main/docs/openapi.json
+++ b/apps/institution-ms/app/src/main/docs/openapi.json
@@ -1698,6 +1698,15 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "productId",
+          "in" : "query",
+          "description" : "productId",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/apps/institution-ms/app/src/test/resources/db/institution.json
+++ b/apps/institution-ms/app/src/test/resources/db/institution.json
@@ -594,9 +594,9 @@
         },
         "createdAt": "2024-06-04T13:39:01.30130241Z",
         "_class": "it.pagopa.selfcare.mscore.model.institution.Onboarding",
-        "origin": "IPA",
-        "originId": "isticom",
-        "institutionType": "PA"
+        "origin": "SELC",
+        "originId": "123X",
+        "institutionType": "PT"
       }
     ],
     "geographicTaxonomies": [

--- a/apps/institution-ms/app/src/test/resources/db/institution.json
+++ b/apps/institution-ms/app/src/test/resources/db/institution.json
@@ -74,9 +74,9 @@
         },
         "createdAt": "2024-07-05T14:43:04.672108422Z",
         "_class": "it.pagopa.selfcare.mscore.model.institution.Onboarding",
-        "origin": "IPA",
-        "originId": "c_c067",
-        "institutionType": "PA"
+        "origin": "SELC",
+        "originId": "123X",
+        "institutionType": "PT"
       }
     ],
     "geographicTaxonomies": [

--- a/apps/institution-ms/app/src/test/resources/features/external.feature
+++ b/apps/institution-ms/app/src/test/resources/features/external.feature
@@ -26,7 +26,7 @@ Feature: External
     And The response body contains at path "[0].onboarding" the following list of objects in any order:
       | productId   | tokenId                              | status | origin | originId | institutionType |
       | prod-pagopa | afb6c11d-67f8-44f9-b04f-88d47e0d2fc3 | ACTIVE | IPA    | isticom  | PA              |
-      | prod-io     | 24534011-a806-4137-855c-059ea9b943cd | ACTIVE | IPA    | isticom  | PA              |
+      | prod-io     | 24534011-a806-4137-855c-059ea9b943cd | ACTIVE | SELC   | 123X     | PT              |
 
   Scenario: Bad request while while getting institutions data by ids
     Given User login with username "j.doe" and password "test"

--- a/apps/institution-ms/app/src/test/resources/features/institution.feature
+++ b/apps/institution-ms/app/src/test/resources/features/institution.feature
@@ -112,7 +112,7 @@ Feature: Institution
     Given User login with username "j.doe" and password "test"
     And The following query params:
       | origin    | SELC    |
-      | originId  | 123X |
+      | originId  | 123X    |
       | productId | prod-io |
     When I send a GET request to "/institutions"
     Then The status code is 200
@@ -1426,13 +1426,35 @@ Feature: Institution
       | prod-interop | cdd3d4bb-bae3-4187-af16-53ec40358267 | ACTIVE | PA              | IPA    | c_c067   |
       | prod-fd      | a3f2d517-b432-4745-ae9b-5bb1f1bcfb79 | ACTIVE | PA              | IPA    | c_c067   |
       | prod-io      | 5eeaf667-e9c1-4150-bb4b-1fce01df6ab9 | ACTIVE | PA              | IPA    | c_c067   |
-      | prod-pagopa  | 6c4fc5c1-65bb-496c-ae0a-547a4c920bd9 | ACTIVE | PA              | IPA    | c_c067   |
+      | prod-pagopa  | 6c4fc5c1-65bb-496c-ae0a-547a4c920bd9 | ACTIVE | PT              | SELC   | 123X     |
     And The response body contains:
       | id              | c9a50656-f345-4c81-84be-5b2474470544                        |
       | logo            | test-logo-url/c9a50656-f345-4c81-84be-5b2474470544/logo.png |
       | origin          | IPA                                                         |
       | originId        | c_c067                                                      |
       | institutionType | PA                                                          |
+      | description     | Comune di Castelbuono                                       |
+      | taxCode         | 00310810825                                                 |
+      | digitalAddress  | comune.castelbuono@pec.it                                   |
+
+  Scenario: Successfully get institution by id with productId filter
+    Given User login with username "j.doe" and password "test"
+    And The following path params:
+      | id | c9a50656-f345-4c81-84be-5b2474470544 |
+    And The following query params:
+      | productId | prod-pagopa |
+    When I send a GET request to "/institutions/{id}"
+    Then The status code is 200
+    And The response body contains the list "onboarding" of size 1
+    And The response body contains at path "onboarding" the following list of objects in any order:
+      | productId    | tokenId                              | status | institutionType | origin | originId |
+      | prod-pagopa  | 6c4fc5c1-65bb-496c-ae0a-547a4c920bd9 | ACTIVE | PT | SELC   | 123X     |
+    And The response body contains:
+      | id              | c9a50656-f345-4c81-84be-5b2474470544                        |
+      | logo            | test-logo-url/c9a50656-f345-4c81-84be-5b2474470544/logo.png |
+      | origin          | SELC                                                        |
+      | originId        | 123X                                                        |
+      | institutionType | PT                                                          |
       | description     | Comune di Castelbuono                                       |
       | taxCode         | 00310810825                                                 |
       | digitalAddress  | comune.castelbuono@pec.it                                   |
@@ -1478,9 +1500,9 @@ Feature: Institution
       | onboardings[0].billing.vatNumber      | 00750840175                          |
       | onboardings[0].billing.recipientCode  | UF7ECB                               |
       | onboardings[0].billing.publicServices | true                                 |
-      | onboardings[0].institutionType        | PA                                   |
-      | onboardings[0].origin                 | IPA                                  |
-      | onboardings[0].originId               | c_c067                               |
+      | onboardings[0].institutionType        | PT                                   |
+      | onboardings[0].origin                 | SELC                                 |
+      | onboardings[0].originId               | 123X                                 |
 
   Scenario: Get onboardings on institution not found
     Given User login with username "j.doe" and password "test"
@@ -1589,7 +1611,7 @@ Feature: Institution
       | prod-io                       | ACTIVE                     | contracts/template/io/2.4.2/io-accordo_di_adesione-v.2.4.2.html | PSP                                 | SELC                       | PSP_15555555555              |
     And The response body contains at path "items" the following list of objects in any order:
       | onboardings.prod-pagopa.productId | onboardings.prod-pagopa.status | onboardings.prod-pagopa.contract | onboardings.prod-pagopa.institutionType | onboardings.prod-pagopa.origin | onboardings.prod-pagopa.originId |
-      | prod-pagopa                       | ACTIVE                         |                                  | PA                                      | IPA                            | c_c067                           |
+      | prod-pagopa                       | ACTIVE                         |                                  | PT                                      | SELC                           | 123X                             |
       | prod-pagopa                       | ACTIVE                         |                                  | PSP                                     | SELC                           | PSP_15555555555                  |
     And The response body contains at path "items" the following list of objects in any order:
       | onboardings.prod-fd.productId | onboardings.prod-fd.status | onboardings.prod-fd.contract                                                                          | onboardings.prod-fd.institutionType | onboardings.prod-fd.origin | onboardings.prod-fd.originId |

--- a/apps/institution-ms/app/src/test/resources/features/institution.feature
+++ b/apps/institution-ms/app/src/test/resources/features/institution.feature
@@ -111,8 +111,8 @@ Feature: Institution
   Scenario: Successfully getInstitutions with origin,originId,productId
     Given User login with username "j.doe" and password "test"
     And The following query params:
-      | origin    | IPA     |
-      | originId  | isticom |
+      | origin    | SELC    |
+      | originId  | 123X |
       | productId | prod-io |
     When I send a GET request to "/institutions"
     Then The status code is 200
@@ -121,13 +121,15 @@ Feature: Institution
     And The response body contains:
       | institutions[0].id                            | fc5466e5-df00-4800-9ad5-aa2e7d9344f9 |
       | institutions[0].taxCode                       | 94076720658                          |
-      | institutions[0].origin                        | IPA                                  |
-      | institutions[0].originId                      | isticom                              |
+      | institutions[0].origin                        | SELC                                 |
+      | institutions[0].originId                      | 123X                                 |
+      | institutions[0].institutionType               | PT                                   |
       | institutions[0].isTest                        | true                                 |
       | institutions[0].onboarding[0].productId       | prod-io                              |
-      | institutions[0].onboarding[0].origin          | IPA                                  |
-      | institutions[0].onboarding[0].originId        | isticom                              |
-      | institutions[0].onboarding[0].institutionType | PA                                   |
+      | institutions[0].onboarding[0].origin          | SELC                                 |
+      | institutions[0].onboarding[0].originId        | 123X                                 |
+      | institutions[0].onboarding[0].institutionType | PT                                   |
+
 
   Scenario: Validation error in getInstitutions without taxCode,origin,originId
     Given User login with username "j.doe" and password "test"

--- a/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
+++ b/apps/institution-ms/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
@@ -30,6 +30,8 @@ public interface InstitutionConnector {
 
     Institution findById(String id);
 
+    Institution findByIdAndProduct(String id, String productId);
+
     Institution findAndUpdateStatus(String id, String tokenId, RelationshipState state);
 
     Institution findAndAddOnboarding(String id, Onboarding onboarding);

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -366,10 +366,17 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
     @Override
     public List<Institution> findByOriginAndOriginId(String origin, String originId, String productId) {
 
-        CriteriaBuilder criteriaBuilder = CriteriaBuilder.builder()
-                .isIfNotNull(InstitutionEntity.Fields.origin.name(), origin)
-                .isIfNotNull(InstitutionEntity.Fields.originId.name(), originId)
-                .isIfNotNull("onboarding.productId", productId);
+        CriteriaBuilder criteriaBuilder = CriteriaBuilder.builder();
+
+        Optional.ofNullable(productId).ifPresentOrElse(
+                product -> criteriaBuilder
+                        .isIfNotNull("onboarding.origin", origin)
+                        .isIfNotNull("onboarding.originId", originId)
+                        .isIfNotNull("onboarding.productId", product),
+                () -> criteriaBuilder
+                        .isIfNotNull(InstitutionEntity.Fields.origin.name(), origin)
+                        .isIfNotNull(InstitutionEntity.Fields.originId.name(), originId)
+        );
 
         List<InstitutionEntity> institutionEntities = repository.find(Query.query(criteriaBuilder.build()), InstitutionEntity.class);
 

--- a/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/apps/institution-ms/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -94,6 +94,29 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
     }
 
     @Override
+    public Institution findByIdAndProduct(String id, String productId) {
+        Institution institutionResponse = findById(id);
+
+        if (productId != null) {
+
+            List<Onboarding> onboardings = Optional.ofNullable(institutionResponse.getOnboarding())
+                    .filter(list -> !list.isEmpty())
+                    .orElseThrow(() -> new ResourceNotFoundException(String.format(INSTITUTION_NOT_FOUND.getMessage(), id, "UNDEFINED"), INSTITUTION_NOT_FOUND.getCode()))
+                    .stream()
+                    .filter(onboarding -> productId.equals(onboarding.getProductId()))
+                    .toList();
+
+            if (onboardings.isEmpty()) {
+                throw new ResourceNotFoundException(String.format(INSTITUTION_NOT_FOUND.getMessage(), id, "UNDEFINED"), INSTITUTION_NOT_FOUND.getCode());
+            }
+
+            institutionResponse.setOnboarding(onboardings);
+        }
+
+        return institutionResponse;
+    }
+
+    @Override
     public Institution findAndUpdateStatus(String institutionId, String tokenId, RelationshipState status) {
         OffsetDateTime now = OffsetDateTime.now();
 

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -17,6 +17,8 @@ public interface InstitutionService {
 
     Institution retrieveInstitutionById(String id);
 
+    Institution retrieveInstitutionByIdAndProduct(String id, String productId);
+
     Institution retrieveInstitutionByExternalId(String institutionExternalId);
 
     List<Institution> getInstitutions(String taxCode, String subunitCode, String origin, String originId, String productId, Boolean enableSubunits);

--- a/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/apps/institution-ms/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -72,6 +72,11 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
+    public Institution retrieveInstitutionByIdAndProduct(String id, String productId) {
+        return institutionConnector.findByIdAndProduct(id, productId);
+    }
+
+    @Override
     public Institution retrieveInstitutionByExternalId(String institutionExternalId) {
         Optional<Institution> opt = institutionConnector.findByExternalId(institutionExternalId);
         if (opt.isEmpty()) {

--- a/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/apps/institution-ms/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -75,12 +75,18 @@ class InstitutionServiceImplTest {
     @Spy
     private TokenMapper tokenMapper = new TokenMapperImpl();
 
+    private CategoryProxyInfo createCategoryProxyInfo() {
+        CategoryProxyInfo dummyCategoryProxyInfo = new CategoryProxyInfo();
+        dummyCategoryProxyInfo.setCode("Code");
+        dummyCategoryProxyInfo.setKind("Kind");
+        dummyCategoryProxyInfo.setName("Name");
+        dummyCategoryProxyInfo.setOrigin("Origin");
 
-    private static final InstitutionProxyInfo dummyInstitutionProxyInfo;
-    private static final CategoryProxyInfo dummyCategoryProxyInfo;
+        return dummyCategoryProxyInfo;
+    }
 
-    static {
-        dummyInstitutionProxyInfo = new InstitutionProxyInfo();
+    private InstitutionProxyInfo createInstitutionProxyInfo() {
+        InstitutionProxyInfo dummyInstitutionProxyInfo = new InstitutionProxyInfo();
         dummyInstitutionProxyInfo.setAddress("42 Main St");
         dummyInstitutionProxyInfo.setAoo("Aoo");
         dummyInstitutionProxyInfo.setCategory("Category");
@@ -94,11 +100,7 @@ class InstitutionServiceImplTest {
         dummyInstitutionProxyInfo.setTaxCode("Tax Code");
         dummyInstitutionProxyInfo.setZipCode("21654");
 
-        dummyCategoryProxyInfo = new CategoryProxyInfo();
-        dummyCategoryProxyInfo.setCode("Code");
-        dummyCategoryProxyInfo.setKind("Kind");
-        dummyCategoryProxyInfo.setName("Name");
-        dummyCategoryProxyInfo.setOrigin("Origin");
+        return dummyInstitutionProxyInfo;
     }
 
 
@@ -122,6 +124,28 @@ class InstitutionServiceImplTest {
                 .thenThrow(new ResourceNotFoundException("An error occurred", "Code"));
         assertThrows(ResourceNotFoundException.class, () -> institutionServiceImpl.retrieveInstitutionById("42"));
         verify(institutionConnector).findById(any());
+    }
+
+    /**
+     * Method under test: {@link InstitutionServiceImpl#retrieveInstitutionByIdAndProduct(String, String)}
+     */
+    @Test
+    void testRetrieveInstitutionByIdAndProduct() {
+        Institution institution = new Institution();
+        when(institutionConnector.findByIdAndProduct(any(), anyString())).thenReturn(institution);
+        assertSame(institution, institutionServiceImpl.retrieveInstitutionByIdAndProduct("42", "productId"));
+        verify(institutionConnector).findByIdAndProduct(any(), anyString());
+    }
+
+    /**
+     * Method under test: {@link InstitutionServiceImpl#retrieveInstitutionByIdAndProduct(String, String)}
+     */
+    @Test
+    void testRetrieveInstitutionByIdAndProduct_withException() {
+        when(institutionConnector.findByIdAndProduct(any(), anyString()))
+                .thenThrow(new ResourceNotFoundException("An error occurred", "Code"));
+        assertThrows(ResourceNotFoundException.class, () -> institutionServiceImpl.retrieveInstitutionByIdAndProduct("42", "productId"));
+        verify(institutionConnector).findByIdAndProduct(any(), anyString());
     }
 
     /**
@@ -175,8 +199,8 @@ class InstitutionServiceImplTest {
         when(institutionConnector.save(any())).thenReturn(institution);
         when(institutionConnector.findByExternalId(any())).thenReturn(Optional.empty());
 
-        when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
-        when(partyRegistryProxyConnector.getInstitutionById(any())).thenReturn(dummyInstitutionProxyInfo);
+        when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(createCategoryProxyInfo());
+        when(partyRegistryProxyConnector.getInstitutionById(any())).thenReturn(createInstitutionProxyInfo());
         assertSame(institution, institutionServiceImpl.createInstitutionByExternalId("42"));
         verify(institutionConnector).save(any());
         verify(institutionConnector).findByExternalId(any());
@@ -193,8 +217,8 @@ class InstitutionServiceImplTest {
                 .thenThrow(new ResourceConflictException("An error occurred", "START - check institution {} already exists"));
         when(institutionConnector.findByExternalId(any())).thenReturn(Optional.empty());
 
-        when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
-        when(partyRegistryProxyConnector.getInstitutionById(any())).thenReturn(dummyInstitutionProxyInfo);
+        when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(createCategoryProxyInfo());
+        when(partyRegistryProxyConnector.getInstitutionById(any())).thenReturn(createInstitutionProxyInfo());
         assertThrows(MsCoreException.class, () -> institutionServiceImpl.createInstitutionByExternalId("42"));
         verify(institutionConnector).save(any());
         verify(institutionConnector).findByExternalId(any());
@@ -220,8 +244,8 @@ class InstitutionServiceImplTest {
     @Test
     void testCreateInstitutionByExternalId6() {
 
-        when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
-        when(partyRegistryProxyConnector.getInstitutionById(any())).thenReturn(dummyInstitutionProxyInfo);
+        when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(createCategoryProxyInfo());
+        when(partyRegistryProxyConnector.getInstitutionById(any())).thenReturn(createInstitutionProxyInfo());
         Institution institution = new Institution();
         when(institutionConnector.save(any())).thenReturn(institution);
         when(institutionConnector.findByExternalId(any())).thenReturn(Optional.empty());

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -104,7 +104,7 @@ public class InstitutionController {
         List<Institution> institutions = institutionService.getInstitutions(taxCode, subunitCode, origin, originId, productId, enableSubunits);
         InstitutionsResponse institutionsResponse = new InstitutionsResponse();
         institutionsResponse.setInstitutions(institutions.stream()
-                .map(institutionResourceMapper::toInstitutionResponse)
+                .map(institution -> institutionResourceMapper.toInstitutionResponseWithType(institution, productId))
                 .toList());
         return ResponseEntity.ok(institutionsResponse);
     }
@@ -431,10 +431,11 @@ public class InstitutionController {
     @ApiOperation(value = "${swagger.mscore.institution}", notes = "${swagger.mscore.institution}")
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<InstitutionResponse> retrieveInstitutionById(@ApiParam("${swagger.mscore.institutions.model.institutionId}")
-                                                                       @PathVariable("id") String id) {
+                                                                       @PathVariable("id") String id,
+                                                                       @RequestParam(value = "productId", required = false) String productId) {
         CustomExceptionMessage.setCustomMessage(GenericError.GET_INSTITUTION_BY_ID_ERROR);
-        Institution institution = institutionService.retrieveInstitutionById(id);
-        InstitutionResponse institutionResponse = institutionResourceMapper.toInstitutionResponse(institution);
+        Institution institution = institutionService.retrieveInstitutionByIdAndProduct(id, productId);
+        InstitutionResponse institutionResponse = institutionResourceMapper.toInstitutionResponseWithType(institution, productId);
         institutionResponse.setLogo(institutionService.getLogo(id));
         return ResponseEntity.ok().body(institutionResponse);
     }

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
@@ -21,6 +21,13 @@ public interface InstitutionResourceMapper {
     @Mapping(target = "rootParent", source = ".", qualifiedByName = "setRootParent")
     InstitutionResponse toInstitutionResponse(Institution institution);
 
+    @Mapping(target = "aooParentCode", source = "institution.paAttributes.aooParentCode")
+    @Mapping(target = "rootParent", source = "institution", qualifiedByName = "setRootParent")
+    @Mapping(target = "institutionType", expression = "java(setInstitutionType(institution, productId))")
+    @Mapping(target = "origin", expression = "java(setOrigin(institution, productId))")
+    @Mapping(target = "originId", expression = "java(setOriginId(institution, productId))")
+    InstitutionResponse toInstitutionResponseWithType(Institution institution, String productId);
+
     @Named("setRootParent")
     static RootParentResponse setRootParent(Institution institution) {
         if(StringUtils.hasText(institution.getRootParentId())){
@@ -30,6 +37,30 @@ public interface InstitutionResourceMapper {
             return rootParentResponse;
         }
         return null;
+    }
+
+    @Named("setInstitutionType")
+    default String setInstitutionType(Institution institution, String productId) {
+        return Optional.ofNullable(productId)
+                .filter(id -> !institution.getOnboarding().isEmpty())
+                .map(id -> institution.getOnboarding().get(0).getInstitutionType().name())
+                .orElse(institution.getInstitutionType().name());
+    }
+
+    @Named("setOrigin")
+    default String setOrigin(Institution institution, String productId) {
+        return Optional.ofNullable(productId)
+                .filter(id -> !institution.getOnboarding().isEmpty())
+                .map(id -> institution.getOnboarding().get(0).getOrigin())
+                .orElse(institution.getOrigin());
+    }
+
+    @Named("setOriginId")
+    default String setOriginId(Institution institution, String productId) {
+        return Optional.ofNullable(productId)
+                .filter(id -> !institution.getOnboarding().isEmpty())
+                .map(id -> institution.getOnboarding().get(0).getOriginId())
+                .orElse(institution.getOriginId());
     }
 
     InstitutionGeographicTaxonomies toInstitutionGeographicTaxonomies(GeoTaxonomies geoTaxonomies);

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
 import it.pagopa.selfcare.mscore.model.institution.InstitutionUpdate;
 import it.pagopa.selfcare.mscore.web.model.institution.*;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -43,8 +44,11 @@ public interface InstitutionResourceMapper {
     default String setInstitutionType(Institution institution, String productId) {
         return Optional.ofNullable(productId)
                 .filter(id -> !institution.getOnboarding().isEmpty())
-                .map(id -> institution.getOnboarding().get(0).getInstitutionType().name())
-                .orElse(institution.getInstitutionType().name());
+                .flatMap(id -> Optional.ofNullable(institution.getOnboarding().get(0).getInstitutionType())
+                        .map(InstitutionType::name))
+                .or(() -> Optional.ofNullable(institution.getInstitutionType())
+                        .map(InstitutionType::name))
+                .orElse(null);
     }
 
     @Named("setOrigin")


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- modify logic of getInstitutions to set institutionType, origin and originId equals to the ones related to the product if product filter is present
- add productId filter in retrieveInstitutionById and add logic to set institutionType, origin and originId equals to the ones related to the product if product filter is present
- align unit tests
- align cucumber tests

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested locally, by unit tests and cucumber tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.