### PR TITLE
[SELC-7315] Restored retrieveInstitutionById removing productId filter from db search + safer toInstitutionResponseWithType mapping

### DIFF
--- a/apps/institution-ms/app/src/test/resources/features/institution.feature
+++ b/apps/institution-ms/app/src/test/resources/features/institution.feature
@@ -1445,16 +1445,32 @@ Feature: Institution
       | productId | prod-pagopa |
     When I send a GET request to "/institutions/{id}"
     Then The status code is 200
-    And The response body contains the list "onboarding" of size 1
-    And The response body contains at path "onboarding" the following list of objects in any order:
-      | productId    | tokenId                              | status | institutionType | origin | originId |
-      | prod-pagopa  | 6c4fc5c1-65bb-496c-ae0a-547a4c920bd9 | ACTIVE | PT | SELC   | 123X     |
+    And The response body contains the list "onboarding" of size 4
     And The response body contains:
       | id              | c9a50656-f345-4c81-84be-5b2474470544                        |
       | logo            | test-logo-url/c9a50656-f345-4c81-84be-5b2474470544/logo.png |
       | origin          | SELC                                                        |
       | originId        | 123X                                                        |
       | institutionType | PT                                                          |
+      | description     | Comune di Castelbuono                                       |
+      | taxCode         | 00310810825                                                 |
+      | digitalAddress  | comune.castelbuono@pec.it                                   |
+
+  Scenario: Successfully get institution by id with productId filter not found
+    Given User login with username "j.doe" and password "test"
+    And The following path params:
+      | id | c9a50656-f345-4c81-84be-5b2474470544 |
+    And The following query params:
+      | productId | prod-x |
+    When I send a GET request to "/institutions/{id}"
+    Then The status code is 200
+    And The response body contains the list "onboarding" of size 4
+    And The response body contains:
+      | id              | c9a50656-f345-4c81-84be-5b2474470544                        |
+      | logo            | test-logo-url/c9a50656-f345-4c81-84be-5b2474470544/logo.png |
+      | origin          | IPA                                                         |
+      | originId        | c_c067                                                      |
+      | institutionType | PA                                                          |
       | description     | Comune di Castelbuono                                       |
       | taxCode         | 00310810825                                                 |
       | digitalAddress  | comune.castelbuono@pec.it                                   |

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -434,7 +434,7 @@ public class InstitutionController {
                                                                        @PathVariable("id") String id,
                                                                        @RequestParam(value = "productId", required = false) String productId) {
         CustomExceptionMessage.setCustomMessage(GenericError.GET_INSTITUTION_BY_ID_ERROR);
-        Institution institution = institutionService.retrieveInstitutionByIdAndProduct(id, productId);
+        Institution institution = institutionService.retrieveInstitutionById(id);
         InstitutionResponse institutionResponse = institutionResourceMapper.toInstitutionResponseWithType(institution, productId);
         institutionResponse.setLogo(institutionService.getLogo(id));
         return ResponseEntity.ok().body(institutionResponse);

--- a/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
+++ b/apps/institution-ms/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
@@ -42,28 +42,30 @@ public interface InstitutionResourceMapper {
 
     @Named("setInstitutionType")
     default String setInstitutionType(Institution institution, String productId) {
+        final String parentInstitutionType = Optional.ofNullable(institution.getInstitutionType()).map(InstitutionType::name).orElse(null);
         return Optional.ofNullable(productId)
-                .filter(id -> !institution.getOnboarding().isEmpty())
-                .flatMap(id -> Optional.ofNullable(institution.getOnboarding().get(0).getInstitutionType())
-                        .map(InstitutionType::name))
-                .or(() -> Optional.ofNullable(institution.getInstitutionType())
-                        .map(InstitutionType::name))
-                .orElse(null);
+                .flatMap(pid -> Optional.ofNullable(institution.getOnboarding()))
+                .flatMap(onb -> onb.stream().filter(o -> o.getProductId().equals(productId)).findFirst())
+                .flatMap(o -> Optional.ofNullable(o.getInstitutionType()))
+                .map(InstitutionType::name)
+                .orElse(parentInstitutionType);
     }
 
     @Named("setOrigin")
     default String setOrigin(Institution institution, String productId) {
         return Optional.ofNullable(productId)
-                .filter(id -> !institution.getOnboarding().isEmpty())
-                .map(id -> institution.getOnboarding().get(0).getOrigin())
+                .flatMap(pid -> Optional.ofNullable(institution.getOnboarding()))
+                .flatMap(onb -> onb.stream().filter(o -> o.getProductId().equals(productId)).findFirst())
+                .flatMap(o -> Optional.ofNullable(o.getOrigin()))
                 .orElse(institution.getOrigin());
     }
 
     @Named("setOriginId")
     default String setOriginId(Institution institution, String productId) {
         return Optional.ofNullable(productId)
-                .filter(id -> !institution.getOnboarding().isEmpty())
-                .map(id -> institution.getOnboarding().get(0).getOriginId())
+                .flatMap(pid -> Optional.ofNullable(institution.getOnboarding()))
+                .flatMap(onb -> onb.stream().filter(o -> o.getProductId().equals(productId)).findFirst())
+                .flatMap(o -> Optional.ofNullable(o.getOriginId()))
                 .orElse(institution.getOriginId());
     }
 

--- a/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/apps/institution-ms/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -291,7 +291,7 @@ class InstitutionControllerTest {
     void retrieveInstitutionById_withProductFilter() throws Exception {
         SecurityContext securityContext = Mockito.mock(SecurityContext.class);
         SecurityContextHolder.setContext(securityContext);
-        when(institutionService.retrieveInstitutionByIdAndProduct("42", "example")).thenReturn(createInstitution());
+        when(institutionService.retrieveInstitutionById("42")).thenReturn(createInstitution());
         when(institutionService.getLogo("42")).thenReturn("logoUrl");
         createInstitution().setId("id");
         MockHttpServletRequestBuilder requestBuilder = 
@@ -309,7 +309,7 @@ class InstitutionControllerTest {
      */
     @Test
     void testRetrieveInstitutionById() throws Exception {
-        when(institutionService.retrieveInstitutionByIdAndProduct(any(), eq(null))).thenReturn(createInstitution());
+        when(institutionService.retrieveInstitutionById(any())).thenReturn(createInstitution());
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/institutions/{id}", "42");
         MockMvcBuilders.standaloneSetup(institutionController)
                 .build()


### PR DESCRIPTION
#### List of Changes

- Removed productId filter from db search in retrieveInstitutionById
- Improved mapping to handle cases where the onboarding node is not present in Institution
- Improved mapping to search the productId in the onboarding node and not depend on the fact that the input array is already filtered

#### Motivation and Context

The API should not return 404 if the productId in request is not present inside the institution to not introduce a breaking change towards external callers

#### How Has This Been Tested?

- Local tests
- Unit tests
- Integration tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.