### PR TITLE
Using amazoncorretto as runtime

### DIFF
--- a/apps/institution-ms/Dockerfile
+++ b/apps/institution-ms/Dockerfile
@@ -29,7 +29,7 @@ ARG REPO_PASSWORD
 
 RUN mvn --global-settings settings.xml --projects :institution-ms -DrepositoryId=${REPO_ONBOARDING} -DrepoLogin=${REPO_USERNAME} -DrepoPwd=${REPO_PASSWORD} --also-make-dependents clean package -DskipTests
 
-FROM openjdk:17-jdk@sha256:528707081fdb9562eb819128a9f85ae7fe000e2fbaeaf9f87662e7b3f38cb7d8 AS runtime
+FROM amazoncorretto:17@sha256:3f08e3e4271666c2bb048bbd084f7cb0dad2471fa0058e5b080b4c1004c3abf0 AS runtime
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 


### PR DESCRIPTION
#### List of Changes

- Using amazoncorretto as runtime

#### Motivation and Context

openjdk images on docker hub are described as "Pre-release / non-production builds of OpenJDK"

#### How Has This Been Tested?

- Github Actions

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.