### PR TITLE
[SELC-8331] Eclipse Temurin

### DIFF
--- a/apps/delegation-cdc/Dockerfile
+++ b/apps/delegation-cdc/Dockerfile
@@ -48,4 +48,4 @@ RUN chmod 755 ./applicationinsights-agent.jar
 EXPOSE 8080
 USER 1001
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /app/quarkus-run.jar"]
+ENTRYPOINT ["bash", "-c", "java $JAVA_OPTIONS -jar /app/quarkus-run.jar"]

--- a/apps/delegation-cdc/Dockerfile
+++ b/apps/delegation-cdc/Dockerfile
@@ -30,7 +30,7 @@ ARG REPO_PASSWORD
 
 RUN mvn --global-settings settings.xml --projects :delegation-cdc -DrepositoryId=${REPO_ONBOARDING} -DrepoLogin=${REPO_USERNAME} -DrepoPwd=${REPO_PASSWORD} --also-make clean package -DskipTests
 
-FROM openjdk:17-jdk@sha256:528707081fdb9562eb819128a9f85ae7fe000e2fbaeaf9f87662e7b3f38cb7d8 AS runtime
+FROM eclipse-temurin:17@sha256:d838da85ec7aa8fd72b613e30b5f7629d8f5ac70a4264d45735a8a2ed9af447c AS runtime
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"

--- a/apps/institution-ms/Dockerfile
+++ b/apps/institution-ms/Dockerfile
@@ -29,7 +29,7 @@ ARG REPO_PASSWORD
 
 RUN mvn --global-settings settings.xml --projects :institution-ms -DrepositoryId=${REPO_ONBOARDING} -DrepoLogin=${REPO_USERNAME} -DrepoPwd=${REPO_PASSWORD} --also-make-dependents clean package -DskipTests
 
-FROM eclipse-temurin:17-jre@sha256:7a7b6ad2ab918a29b9b2b87b34158a4b5ad20d23dee33687306359eca2d8063e AS runtime
+FROM eclipse-temurin:17@sha256:d838da85ec7aa8fd72b613e30b5f7629d8f5ac70a4264d45735a8a2ed9af447c AS runtime
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/apps/institution-ms/Dockerfile
+++ b/apps/institution-ms/Dockerfile
@@ -29,7 +29,7 @@ ARG REPO_PASSWORD
 
 RUN mvn --global-settings settings.xml --projects :institution-ms -DrepositoryId=${REPO_ONBOARDING} -DrepoLogin=${REPO_USERNAME} -DrepoPwd=${REPO_PASSWORD} --also-make-dependents clean package -DskipTests
 
-FROM amazoncorretto:17@sha256:3f08e3e4271666c2bb048bbd084f7cb0dad2471fa0058e5b080b4c1004c3abf0 AS runtime
+FROM eclipse-temurin:17-jre@sha256:7a7b6ad2ab918a29b9b2b87b34158a4b5ad20d23dee33687306359eca2d8063e AS runtime
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 

--- a/apps/institution-send-mail-scheduler/Dockerfile
+++ b/apps/institution-send-mail-scheduler/Dockerfile
@@ -30,7 +30,7 @@ ARG REPO_PASSWORD
 
 RUN mvn --global-settings settings.xml --projects :institution-send-mail-scheduler -DrepositoryId=${REPO_ONBOARDING} -DrepoLogin=${REPO_USERNAME} -DrepoPwd=${REPO_PASSWORD} --also-make clean package -DskipTests
 
-FROM openjdk:17-jdk@sha256:528707081fdb9562eb819128a9f85ae7fe000e2fbaeaf9f87662e7b3f38cb7d8 AS runtime
+FROM eclipse-temurin:17@sha256:d838da85ec7aa8fd72b613e30b5f7629d8f5ac70a4264d45735a8a2ed9af447c AS runtime
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"

--- a/apps/institution-send-mail-scheduler/Dockerfile
+++ b/apps/institution-send-mail-scheduler/Dockerfile
@@ -48,4 +48,4 @@ RUN chmod 755 ./applicationinsights-agent.jar
 EXPOSE 8080
 USER 1001
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /app/quarkus-run.jar"]
+ENTRYPOINT ["bash", "-c", "java $JAVA_OPTIONS -jar /app/quarkus-run.jar"]


### PR DESCRIPTION
#### List of Changes

- Updated runtime to eclipse-temurin

#### Motivation and Context

OpenJDK is deprecated, eclipse-temurin is a production ready vendor-neutral, cloud-neutral alternative
